### PR TITLE
add x axis overflow handeling on article page and sidebar templates

### DIFF
--- a/docs/.vuepress/styles/wrapper.styl
+++ b/docs/.vuepress/styles/wrapper.styl
@@ -1,4 +1,6 @@
 $wrapper
   max-width $contentWidth
   margin 0 3rem
+  overflow-x hidden
+  white-space normal
 

--- a/docs/.vuepress/theme/sidebar/Sidebar.vue
+++ b/docs/.vuepress/theme/sidebar/Sidebar.vue
@@ -186,4 +186,6 @@ onUnmounted(() => {
     top 3.875rem !important
     background #FFFFFF !important
     z-index 999
+    overflow-x hidden
+    white-space normal
 </style>


### PR DESCRIPTION
missing X axis overflow handling rule used to cause responsiveness problems.

I added a rule in `docs/.vuepress/styles/wrapper.styl` to handle overflow in Article page template.

I added a rule in `docs/.vuepress/theme/sidebar/Sidebar.vue` to handle overflow in sidebar template.
