### PR TITLE
Added links to AlmaLinux 9.2 FIPS & ESU OVAL data.

### DIFF
--- a/docs/enterprise-support-for-almalinux/README.md
+++ b/docs/enterprise-support-for-almalinux/README.md
@@ -55,7 +55,10 @@ ESU provides qualified security and selected bug-fix errata advisories across al
 
 ### OVAL patch definitions
 
-Leveraging Open Vulnerability and Assessment Language (OVAL) patch definitions with OVAL-compatible tools, e.g. OpenSCAP, users can accurately check their systems for the presence of vulnerabilities.
+Leveraging Open Vulnerability and Assessment Language (OVAL) patch definitions with OVAL-compatible tools, e.g. OpenSCAP, users can accurately check their systems for the presence of vulnerabilities:
+
+* AlmaLinux 9.2 FIPS: [https://repo.tuxcare.com/tuxcare/9/almalinux9.2-fips-oval.xml](https://repo.tuxcare.com/tuxcare/9/almalinux9.2-fips-oval.xml)
+* AlmaLinux 9.2 ESU: [https://repo.tuxcare.com/tuxcare/9/almalinux9.2-esu-oval.xml](https://repo.tuxcare.com/tuxcare/9/almalinux9.2-esu-oval.xml)
 
 ### Technical support
 


### PR DESCRIPTION
We previously described being able to use OVAL data but didn't provide links to the feeds.