### PR TITLE
Repo warnings and upgrade process instructions

### DIFF
--- a/docs/enterprise-support-for-almalinux/README.md
+++ b/docs/enterprise-support-for-almalinux/README.md
@@ -433,10 +433,21 @@ You can browse [https://repo.tuxcare.com/tuxcare/](https://repo.tuxcare.com/tuxc
 # dnf -y install https://repo.tuxcare.com/tuxcare/tuxcare-release-latest-8.10.$(uname -i).rpm
 ```
 
+:::warning
+Be aware that installing tuxcare-release will modify any files that match the wildcard /etc/yum.repos.d/almalinux*
+:::
+
 The second step is to activate your license on the system. You should run the `tuxctl` tool as root with your Essential Support license key provided as a command line argument like so:
 
 ```text
 # tuxctl --license-key ESA-XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Essential Support customers can upgrade to a new minor version, for example from 9.2 to 9.4 by editing the /etc/dnf/vars/tuxcare_releasever file to specify the new version, like so:
+
+```text
+# echo 9.4 > /etc/dnf/vars/tuxcare_releasever
+# dnf upgrade
 ```
 
 :::warning


### PR DESCRIPTION
Added a warning regarding /etc/yum.repos.d/almalinux* files being modified - users could have their own repo's called almalinux*

Added instructions about how to upgrade to a new minor version (for ESA only) as tuxcare-release has to match almalinux-release.