### PR TITLE
TCR-519

### DIFF
--- a/docs/.vuepress/config-client/documents.ts
+++ b/docs/.vuepress/config-client/documents.ts
@@ -30,14 +30,14 @@ export default [
         link: "/eportal-api/",
     },
     {
-        title: "Extended Lifecycle Support",
+        title: "Endless Lifecycle Support",
         description: "allows you to continue running your Linux server after the operating system’s end of life.",
-        link: "/extended-lifecycle-support/",
+        link: "/endless-lifecycle-support/",
     },
     {
-        title: "Extended Lifecycle Support for Languages",
+        title: "Endless Lifecycle Support for Languages",
         description: "provides security fixes for PHP and Python versions that have reached their end-of-life which allows to continue running Linux server vulnerability-free.",
-        link: "/extended-lifecycle-support-for-languages/",
+        link: "/endless-lifecycle-support-for-languages/",
     },
     {
         title: "Subscription Management Portal",

--- a/docs/.vuepress/config-client/sidebar.ts
+++ b/docs/.vuepress/config-client/sidebar.ts
@@ -25,19 +25,19 @@ export default {
             ]
         },
     ],
-    '/extended-lifecycle-support/': [
+    '/endless-lifecycle-support/': [
         {
             collapsable: false,
             children: [
-                "/extended-lifecycle-support/",
+                "/endless-lifecycle-support/",
             ]
         },
     ],
-    '/extended-lifecycle-support-for-languages/': [
+    '/endless-lifecycle-support-for-languages/': [
         {
             collapsable: false,
             children: [
-                "/extended-lifecycle-support-for-languages/",
+                "/endless-lifecycle-support-for-languages/",
             ]
         },
     ],

--- a/docs/.vuepress/routes.json
+++ b/docs/.vuepress/routes.json
@@ -2,5 +2,7 @@
     "/almacare/": "/enterprise-support-for-almalinux/",
     "/service-descriptions/#almacare": "/enterprise-support-for-almalinux/#essential-and-enhanced-support",
     "/eportal/#almacare-cybersecurity-patch-management": "/eportal/#live-patching-for-almalinux-kernelcare-and-libcare-management",
-    "/eportal/#deploying-almacare-almacare-cybersecurity": "/eportal/#deploying-essential-support-live-patching-for-almalinux"
+    "/eportal/#deploying-almacare-almacare-cybersecurity": "/eportal/#deploying-essential-support-live-patching-for-almalinux",
+    "/extended-lifecycle-support": "/endless-lifecycle-support/",
+    "/extended-lifecycle-support-for-languages": "/endless-lifecycle-support-for-languages/"
 }

--- a/docs/endless-lifecycle-support-for-languages/README.md
+++ b/docs/endless-lifecycle-support-for-languages/README.md
@@ -1,12 +1,12 @@
-# Extended Lifecycle Support for Languages
+# Endless Lifecycle Support for Languages
 
-## Extended Lifecycle Support for PHP
+## Endless Lifecycle Support for PHP
 
-Extended Lifecycle Support (ELS) for PHP from TuxCare provides security fixes for PHP versions that have reached their end-of-life. This allows to continue running Linux server vulnerability-free.
+Endless Lifecycle Support (ELS) for PHP from TuxCare provides security fixes for PHP versions that have reached their end-of-life. This allows to continue running Linux server vulnerability-free.
 
 ### Supported OS
 
-TuxCare provides Extended Lifecycle Support through four years after the EOL date.
+TuxCare provides Endless Lifecycle Support through four years after the EOL date.
 
 | OS                                    | Version                                               |
 | :-----------------------------------: | :----------------------------------------------:      |
@@ -359,9 +359,9 @@ zlib
 As you can see, each version is entirely self-contained, and changing configurations in one will not impact the others, a desired feature in hosting environments.
 
 
-## Extended Lifecycle Support for Spring Framework and Spring Boot
+## Endless Lifecycle Support for Spring Framework and Spring Boot
 
-TuxCare's Extended Lifecycle Support (ELS) for Spring provides security updates, system enhancement patches, and selected bug fixes, that are integral to the stable operation of applications running on these versions of Spring ecosystem components such as Spring Framework, Spring Boot, Spring Data, Spring Security, etc. These components have either reached their end of standard support from vendors or have reached End of Life (EOL).
+TuxCare's Endless Lifecycle Support (ELS) for Spring provides security updates, system enhancement patches, and selected bug fixes, that are integral to the stable operation of applications running on these versions of Spring ecosystem components such as Spring Framework, Spring Boot, Spring Data, Spring Security, etc. These components have either reached their end of standard support from vendors or have reached End of Life (EOL).
 
 Our ELS for Spring service is designed to provide solutions for organizations that are not yet ready to migrate to newer versions and that are seeking long-term stability for their legacy Spring applications.
 
@@ -388,7 +388,7 @@ Handling Multiple Vulnerabilities: In cases where several CVEs are reported simu
 
 ### Supported Projects and Duration of Support
 
-TuxCare provides Extended Lifecycle Support (ELS) for more than three years (see the table below for details). This support is offered after the Spring project has reached its End of Life (EOL) or no longer receives standard support.
+TuxCare provides Endless Lifecycle Support (ELS) for more than three years (see the table below for details). This support is offered after the Spring project has reached its End of Life (EOL) or no longer receives standard support.
 
 | Project                | End of OSS Support            | End of TuxCare Support |
 | ---------------------- | ----------------------------- | ---------------------- |
@@ -819,9 +819,9 @@ You've successfully integrated the TuxCare ELS for Spring repository into your p
 | CVE-2023-5685  | HIGH     | org.springframework.boot     | spring-boot-starter-undertow                | 2.7.18        |
 
           
-## Extended Lifecycle Support for Python
+## Endless Lifecycle Support for Python
 
-Extended Lifecycle Support (ELS) for Python from TuxCare provides security fixes for Python 2.7 version for AlmaLinux 9. This allows to continue running Linux server vulnerability-free.
+Endless Lifecycle Support (ELS) for Python from TuxCare provides security fixes for Python 2.7 version for AlmaLinux 9. This allows to continue running Linux server vulnerability-free.
 
 ### Installation instructions of yum repositories
 

--- a/docs/endless-lifecycle-support/README.md
+++ b/docs/endless-lifecycle-support/README.md
@@ -1,6 +1,6 @@
-# Extended Lifecycle Support for OS
+# Endless Lifecycle Support for OS
 
-TuxCare's [Extended Lifecycle Support (ELS) for OS](https://tuxcare.com/extended-lifecycle-support/) service provides security updates, system enhancement patches, and selected bug fixes for older versions of a variety of Linux distributions, including CentOS 6, Oracle Linux 6, CentOS 7, Oracle Linux 7, CentOS 8, CentOS Stream 8, Ubuntu 16.04, and Ubuntu 18.04. These distributions have either reached their end of standard support from vendors or have reached End of Life (EOL).
+TuxCare's [Endless Lifecycle Support (ELS) for OS](https://tuxcare.com/extended-lifecycle-support/) service provides security updates, system enhancement patches, and selected bug fixes for older versions of a variety of Linux distributions, including CentOS 6, Oracle Linux 6, CentOS 7, Oracle Linux 7, CentOS 8, CentOS Stream 8, Ubuntu 16.04, and Ubuntu 18.04. These distributions have either reached their end of standard support from vendors or have reached End of Life (EOL).
 
 Our ELS service is designed to provide solutions for organizations that are not yet ready to migrate to newer versions and that are seeking long-term stability for their out-of-date operating systems. The service coverage includes updates for the Linux kernel and a list of essential packages that are integral to server operations.
 
@@ -8,7 +8,7 @@ Our ELS service is designed to provide solutions for organizations that are not 
 
 TuxCare employs the Common Vulnerability Scoring System (CVSS v3) to assess the severity of security vulnerabilities. Our severity rating system for patching vulnerabilities integrates both NVD scoring and vendor scoring (when available). When the vendor's score is lower than the NVD score, we give priority to the NVD score.
 
-TuxCare Extended Lifecycle Support, by default, provides security patches for High and Critical vulnerabilities (with a 7+ CVSS score). For vulnerabilities rated as Medium (4.0 to 6.9), TuxCare can provide patches for CVE's where mitigations are not available and there is sufficient customer demand.
+TuxCare Endless Lifecycle Support, by default, provides security patches for High and Critical vulnerabilities (with a 7+ CVSS score). For vulnerabilities rated as Medium (4.0 to 6.9), TuxCare can provide patches for CVE's where mitigations are not available and there is sufficient customer demand.
 
 Custom coverage options are available, including a 10-pack of customer-directed patches for clients who need CVEs patched outside of the ELS scope. Specific details regarding these coverage options and their pricing can be obtained by contacting our sales team.
 
@@ -32,24 +32,9 @@ Requests for customer-directed security patches for CVEs that are outside of the
 - Not Vulnerable: The vulnerability does not affect our version
 - Already Fixed: The vulnerability has already been addressed by the vendor
 
-### Duration of support
-
-TuxCare provides Extended Lifecycle Support (ELS) for up to four years (see the table below for exceptions). This support is offered after the Linux distribution has reached its End of Life (EOL) or no longer receives standard support.
-
-| **Distribution** | **Arch** | **EOL** | **ELS** |
-|---|---|---|---|
-| CentOS 6 | x86_64 i386 | November 2020 | November 2026 |
-| CentOS 7 | x86_64 i386 | June 2024 | June 2029 |
-| CentOS 8 | x86_64 | January 2022 | January 2026 |
-| CentOS Stream 8 | x86_64 | June 2024 | June 2028 |
-| Oracle Linux 6 | x86_64 | December 2020 | December 2024 |
-| Oracle Linux 7 | x86_64 | December 2024 | December 2028 |
-| Ubuntu 16.04 | amd64 | April 2021 | April 2025 |
-| Ubuntu 18.04 | amd64 | May 2023 | May 2028 |
-
 ### Supported packages
 
-TuxCare's Extended Lifecycle Support provides updates for a comprehensive list of packages integral to server operations (100+ packages), providing maximum security for your operating system. You can view the full list of supported packages for each operating system, as well as get detailed information on the patched Common Vulnerabilities and Exposures (CVEs), [here](https://cve.tuxcare.com/els/projects). The list of supported packages may change as projects can be added or removed from the list. Support for additional packages can be provided on request.
+TuxCare's Endless Lifecycle Support provides updates for a comprehensive list of packages integral to server operations (100+ packages), providing maximum security for your operating system. You can view the full list of supported packages for each operating system, as well as get detailed information on the patched Common Vulnerabilities and Exposures (CVEs), [here](https://cve.tuxcare.com/els/projects). The list of supported packages may change as projects can be added or removed from the list. Support for additional packages can be provided on request.
 
 ### Live patching for ELS systems 
 
@@ -61,17 +46,17 @@ Please note that if you are using KernelCare on the system that will soon reach 
 
 ### Errata advisories
 
-TuxCare Extended Lifecycle Support provides qualified security and selected bug-fix errata advisories across all architectures. They can help users track which CVEs are resolved and which bugs have been addressed. You can view the full list of released advisories [here](https://cve.tuxcare.com/els/releases).
+TuxCare Endless Lifecycle Support provides qualified security and selected bug-fix errata advisories across all architectures. They can help users track which CVEs are resolved and which bugs have been addressed. You can view the full list of released advisories [here](https://cve.tuxcare.com/els/releases).
 
 ### OVAL patch definitions
 
-Leveraging the [Open Vulnerability and Assessment Language (OVAL)](/extended-lifecycle-support/#oval-data) patch definitions with OVAL-compatible tools, e.g. OpenSCAP, users can accurately check their systems for the presence of vulnerabilities.
+Leveraging the [Open Vulnerability and Assessment Language (OVAL)](/endless-lifecycle-support/#oval-data) patch definitions with OVAL-compatible tools, e.g. OpenSCAP, users can accurately check their systems for the presence of vulnerabilities.
 
 ### Connection to ELS repository
 
-To install the Extended Lifecycle Support repository on a server, you just need to download an installer script and run the script with a key. The installation script will register the server in the CLN with the key, add a PGP key to the server, and create the ELS repository.
+To install the Endless Lifecycle Support repository on a server, you just need to download an installer script and run the script with a key. The installation script will register the server in the CLN with the key, add a PGP key to the server, and create the ELS repository.
 
-In order to use Extended Lifecycle Support, you will need to open TCP port 443 to the following destinations:
+In order to use Endless Lifecycle Support, you will need to open TCP port 443 to the following destinations:
 
 * [cln.cloudlinux.com](http://cln.cloudlinux.com)
 * [repo.cloudlinux.com](http://repo.cloudlinux.com)
@@ -445,7 +430,7 @@ Version: 1-1.0.1
 Architecture: amd64
 Maintainer: Darya Malyavkina <dmalyavkina@cloudlinux.com>
 Installed-Size: 10
-Homepage: https://tuxcare.com/extended-lifecycle-support/
+Homepage: https://tuxcare.com/endless-lifecycle-support/
 Priority: optional
 Section: utils
 Filename: pool/main/e/els-define/els-define_1-1.0.1_amd64.deb

--- a/docs/endless-lifecycle-support/duration-of-support/README.md
+++ b/docs/endless-lifecycle-support/duration-of-support/README.md
@@ -1,0 +1,14 @@
+### Duration of support
+
+TuxCare provides Endless Lifecycle Support (ELS) for up to four years (see the table below for exceptions). This support is offered after the Linux distribution has reached its End of Life (EOL) or no longer receives standard support.
+
+| **Distribution** | **Arch** | **EOL** | **ELS** |
+|---|---|---|---|
+| CentOS 6 | x86_64 i386 | November 2020 | November 2026 |
+| CentOS 7 | x86_64 i386 | June 2024 | June 2029 |
+| CentOS 8 | x86_64 | January 2022 | January 2026 |
+| CentOS Stream 8 | x86_64 | June 2024 | June 2028 |
+| Oracle Linux 6 | x86_64 | December 2020 | December 2024 |
+| Oracle Linux 7 | x86_64 | December 2024 | December 2028 |
+| Ubuntu 16.04 | amd64 | April 2021 | April 2025 |
+| Ubuntu 18.04 | amd64 | May 2023 | May 2028 |


### PR DESCRIPTION
1. Renamed “Extended Lifecycle Support” to “Endless Lifecycle Support” in the documentation content.
2. Updated documentation URLs from /extended-lifecycle-support/ and /extended-lifecycle-support-for-languages/ to /endless-lifecycle-support-for-languages/ and /endless-lifecycle-support-for-languages/ correspondingly.
3. Updated doc blocks on the home page according to the renaming
4. Configured the redirects from the old ULRs
5. Hide the table "Duration of Support" for ELS and made it available via the direct link