### PR TITLE
TCR-670: hide some pages that are published on Tuxcare docs

### DIFF
--- a/docs/service-descriptions/README.md
+++ b/docs/service-descriptions/README.md
@@ -3,33 +3,3 @@
 ## Essential and Enhanced Support
 
 The description of Essential and Enhanced Support for AlmaLinux systems can be found [here](/enterprise-support-for-almalinux/#essential-and-enhanced-support).
-
-## Technical Account Manager
-
-### Technical Account Manager (TAM)
-A Technical Account Manager (TAM) is an extension to TuxCare products to enhance product and support experience.
- 
- * TuxCare provides a technical account manager who can perform the following tasks for up to 8 hours per week.
-  * Provides best-in-practice configuration assistance.
-  * Provides product presentation and training.
-  * Participate in calls every other week identifying and addressing the customer's operational issues related to the TuxCare products.
-  * Organise multi-vendor issue coordination through TuxCare's partners when applicable.
- * The TAM is available for customer requests during regular working hours for the TAM. Outside working hours support is provided through regular TuxCare support.
-
-
-### Dedicated Technical Account Manager (dTAM)
-
-A dedicated Technical Account Manager (dTAM) is an extension to TuxCare products to enhance the product and support experience.
-
- * TuxCare provides a dedicated technical account manager who can perform the following tasks for up to 40 hours per week.
-  * Acts as a primary point of contact for all TuxCare product-related requests from the customer.
-  * Provides best-in-practice configuration assistance.
-  * Provides product presentation and training.
-  * Can assume maintenance and configuration tasks of TuxCare products on the agreement.
-  * Participate in calls every other week identifying and addressing the customer's operational issues related to the TuxCare products.
-  * Organise multi-vendor issue coordination through TuxCare's partners when applicable.
-  * Facilitate integration of customer's ticketing system with TuxCare's when applicable.
-  * Attend applicable TuxCare training and development activities.
- * The dTAM is available for customer requests during regular working hours for the dTAM and is subject to TuxCare leave policies. Outside working hours support is provided through regular TuxCare support.
- * The dTAM will visit the customer's site annually or twice per year according to the agreement.
- * If the dTAM is on annual leave for more than 5 consequent days, TuxCare will assign a temporary account manager. 

--- a/docs/service-descriptions/tam/README.md
+++ b/docs/service-descriptions/tam/README.md
@@ -1,0 +1,29 @@
+# Technical Account Manager
+
+## Technical Account Manager (TAM)
+A Technical Account Manager (TAM) is an extension to TuxCare products to enhance product and support experience.
+ 
+ * TuxCare provides a technical account manager who can perform the following tasks for up to 8 hours per week.
+  * Provides best-in-practice configuration assistance.
+  * Provides product presentation and training.
+  * Participate in calls every other week identifying and addressing the customer's operational issues related to the TuxCare products.
+  * Organise multi-vendor issue coordination through TuxCare's partners when applicable.
+ * The TAM is available for customer requests during regular working hours for the TAM. Outside working hours support is provided through regular TuxCare support.
+
+
+## Dedicated Technical Account Manager (dTAM)
+
+A dedicated Technical Account Manager (dTAM) is an extension to TuxCare products to enhance the product and support experience.
+
+ * TuxCare provides a dedicated technical account manager who can perform the following tasks for up to 40 hours per week.
+  * Acts as a primary point of contact for all TuxCare product-related requests from the customer.
+  * Provides best-in-practice configuration assistance.
+  * Provides product presentation and training.
+  * Can assume maintenance and configuration tasks of TuxCare products on the agreement.
+  * Participate in calls every other week identifying and addressing the customer's operational issues related to the TuxCare products.
+  * Organise multi-vendor issue coordination through TuxCare's partners when applicable.
+  * Facilitate integration of customer's ticketing system with TuxCare's when applicable.
+  * Attend applicable TuxCare training and development activities.
+ * The dTAM is available for customer requests during regular working hours for the dTAM and is subject to TuxCare leave policies. Outside working hours support is provided through regular TuxCare support.
+ * The dTAM will visit the customer's site annually or twice per year according to the agreement.
+ * If the dTAM is on annual leave for more than 5 consequent days, TuxCare will assign a temporary account manager. 


### PR DESCRIPTION
The section "Technical Account Manager" was hidden and for now, available only by the direct link /service-descriptions/tam