### PR TITLE
Adding code/breadcrumbs features

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -13,6 +13,8 @@ import sidebar from "./config-client/sidebar";
 import social from "./config-client/social";
 
 import Chat from "./components/Chat.vue";
+import CodeTabs from "./components/CodeTabs.vue";
+import CodeWithCopy from "./components/CodeWithCopy.vue";
 
 export default defineClientConfig({
     rootComponents: [
@@ -20,6 +22,8 @@ export default defineClientConfig({
     ],
     async enhance({ app }) {
         app.config.globalProperties.$eventBus = mitt();
+        app.component("CodeTabs", CodeTabs);
+        app.component("CodeWithCopy", CodeWithCopy);
     },
     layouts: {
         Layout,

--- a/docs/.vuepress/components/CodeTabs.vue
+++ b/docs/.vuepress/components/CodeTabs.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="code-tabs">
+    <div class="tab-buttons">
+      <button v-for="(tab, index) in tabs" :key="index" :class="{ active: activeTab === index }" @click="activeTab = index">
+        {{ tab.title }}
+      </button>
+    </div>
+
+    <div class="tab-content code-block-wrapper">
+      <button class="copy-button" @click="copyCode" aria-label="Copy code">
+        <svg v-if="!copied" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+          <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/>
+          <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/>
+        </svg>
+        <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+          <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"/>
+        </svg>
+      </button>
+
+      <pre><code ref="codeRef" class="language-bash">{{ tabs[activeTab].content }}</code></pre>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CodeTabs',
+  props: {
+    tabs: {
+      type: Array,
+      required: true
+    }
+  },
+  data() {
+    return {
+      activeTab: 0,
+      copied: false
+    }
+  },
+  watch: {
+    activeTab() {
+      this.highlight()
+    }
+  },
+  mounted() {
+    this.highlight()
+  },
+  methods: {
+    highlight() {
+      this.$nextTick(() => {
+        if (typeof window !== 'undefined' && window.hljs && this.$refs.codeRef) {
+          window.hljs.highlightElement(this.$refs.codeRef)
+        }
+      })
+    },
+    copyCode() {
+      const text = this.tabs[this.activeTab].content
+      navigator.clipboard.writeText(text).then(() => {
+        this.copied = true
+        setTimeout(() => (this.copied = false), 2000)
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.code-tabs {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.tab-buttons {
+  display: flex;
+  background-color: #2d2d2d;
+  border-bottom: 1px solid #444;
+}
+
+.tab-buttons button {
+  padding: 0.85em;
+  flex: 1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+  color: #ccc;
+}
+
+.tab-buttons button.active {
+  color: #fff;
+  border-bottom: 2px solid #1994f9;
+  font-weight: bold;
+}
+
+.tab-content {
+  position: relative;
+  background-color: #2d2d2d;
+  font-family: monospace;
+  padding: 1rem;
+}
+
+.code-block-wrapper {
+  background-color: #2d2d2d;
+  padding: 12px;
+  position: relative;
+  overflow: hidden;
+}
+
+pre {
+  margin: 0;
+  background-color: transparent;
+  color: #2d2d2d;
+  font-size: 14px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-width: 100%;
+  line-height: 1.5;
+  box-shadow: none;
+}
+
+code {
+  color: #ccc;
+  background: none;
+  display: block;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.2rem;
+  z-index: 10;
+}
+
+.copy-button svg {
+  fill: #ccc;
+  width: 20px;
+  height: 20px;
+  transition: fill 0.2s;
+}
+
+.copy-button:hover svg {
+  fill: #1994f9;
+}
+
+.language-bash {
+  font-size: 0.85em;
+  padding: 0;
+}
+</style>
+
+

--- a/docs/.vuepress/components/CodeWithCopy.vue
+++ b/docs/.vuepress/components/CodeWithCopy.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="code-block-wrapper">
+    <button class="copy-button" @click="copyCode" aria-label="Copy code">
+      <svg v-if="!copied" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="copy-icon">
+        <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+        <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+      </svg>
+      <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="copy-icon">
+        <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
+      </svg>
+    </button>
+    <slot />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const copied = ref(false);
+
+function copyCode() {
+  const code = document.querySelector('.code-block-wrapper pre code')?.innerText;
+  if (code) {
+    navigator.clipboard.writeText(code);
+    copied.value = true;
+    
+    setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  }
+}
+</script>
+
+<style scoped>
+.copy-button svg {
+  transition: fill 0.3s;
+}
+
+.copy-icon {
+  fill: #ccc;
+  width: 20px;
+  height: 20px;
+}
+
+.code-block-wrapper {
+  position: relative;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.2rem;
+  z-index: 10;
+}
+
+.copy-button:hover .copy-icon {
+  fill: #1994f9;
+}
+</style>
+

--- a/docs/.vuepress/theme/components/Breadcrumb.vue
+++ b/docs/.vuepress/theme/components/Breadcrumb.vue
@@ -1,24 +1,50 @@
 <template>
   <div class="breadcrumb-wrapper">
-      <span class="breadcrumb-title">{{ siteTitle }}:</span>
-    <router-link class="breadcrumb" v-for="crumb in breadCrumbs" :key="crumb.path" :to="crumb.path">
+    <router-link
+      v-for="(crumb, index) in breadCrumbs"
+      :key="crumb.path"
+      class="breadcrumb"
+      :to="crumb.path"
+    >
       {{ crumb.title }}
     </router-link>
   </div>
 </template>
 
 <script setup>
-import {computed, inject} from "vue";
-import {usePageData, useSiteData} from "@vuepress/client";
+import { computed } from "vue";
+import { usePageData, useSiteData } from "@vuepress/client";
 
-const page = usePageData()
-const site = useSiteData()
-const { locales: {siteTitle}} = inject("themeConfig")
+const page = usePageData();
+const site = useSiteData();
+
+const siteTitle = computed(() => site.value.title);
+
+const titleMap = {
+  '/els-for-languages/': 'ELS for Languages',
+};
+
 const breadCrumbs = computed(() => {
-    const crumbs = [];
-    if (page.value.path !== '/') {
-      crumbs.push({path: page.value.path, title: page.value.title});
+  const segments = page.value.path.split("/").filter(Boolean);
+  const crumbs = [{ path: "/", title: "Documentation" }];
+  let cumulativePath = "";
+
+  for (let i = 0; i < segments.length; i++) {
+    cumulativePath += `/${segments[i]}`;
+    const isLast = i === segments.length - 1;
+    const fullPath = cumulativePath.endsWith(".html") ? cumulativePath : `${cumulativePath}/`;
+
+    let title;
+
+    if (isLast) {
+      title = page.value.title;
+    } else {
+      title = titleMap[fullPath] || fullPath;
     }
+
+    crumbs.push({ path: fullPath, title });
+  }
+
   return crumbs;
 });
 </script>
@@ -28,17 +54,26 @@ const breadCrumbs = computed(() => {
 
 .breadcrumb
   color $breadcrumbColor
+  text-decoration none
 
-  &::after
+  &:not(:last-child)::after
     content " > "
     font-family inherit
     font-size inherit
+    color $breadcrumbColor
+
+  &:not(:last-child)
+    cursor pointer
+
+    &:hover
+      color #1994f9
 
   &:last-child
     cursor default
+    color $breadcrumbColor
 
-.breadcrumb-title
-  color $breadcrumbColor
-  font-weight 600
-  margin-right 2px
+
 </style>
+
+
+

--- a/docs/els-for-languages/php/README.md
+++ b/docs/els-for-languages/php/README.md
@@ -35,36 +35,62 @@ These steps are suitable for RPM-based systems (CentOS, CloudLinux, AlmaLinux, O
 
 1. Download the installer script:
 
-    ```text
+    <CodeWithCopy>
+
+    ```
     wget https://repo.cloudlinux.com/php-els/install-php-els-rpm-repo.sh
     ```
+
+    </CodeWithCopy>    
 
 2. Run the installer script with keys. The installation script registers the server in the CLN with the key, adds the yum repository, and adds a PGP key to the server.
 
     ```text
     sh install-php-els-rpm-repo.sh --license-key XXX-XXXXXXXXXXXX
     ```
-
+    <CodeTabs :tabs="[
+      { title: 'rpm', content: 'sh install-php-els-rpm-repo.sh --license-key XXX-XXXXXXXXXXXX' },
+      { title: 'deb', content: 'bash install-php-els-deb-repo.sh --license-key XXX-XXXXXXXXXXXX' }
+    ]" />
 3. Verify that the installation was successful.
 
     To ensure the installation has been completed successfully, run the following command. It should return info about a package. If information about the package is available it means that installation was successful. After which, updates will be available for installation from the repository using the usual `yum upgrade` command.
 
-    ```text
-    yum info alt-php73
-
-    Available Packages
-    Name        : alt-php73
-    Arch        : x86_64
-    Epoch       : 1
-    Version     : 7.3.33
-    Release     : 5.2.el7
-    Size        : 22 k
-    Repo        : php-els/7
-    Summary     : PHP scripting language for creating dynamic web sites
-    URL         : http://www.php.net/
-    License     : PHP and LGPLv2 and LGPLv2+
-    Description : PHP is an HTML-embedded scripting language.
-    ```
+<CodeTabs :tabs="[
+{ title: 'rpm', content: 
+`yum info alt-php73\n
+Available Packages
+Name        : alt-php73
+Arch        : x86_64
+Epoch       : 1
+Version     : 7.3.33
+Release     : 5.2.el7
+Size        : 22 k
+Repo        : php-els/7
+Summary     : PHP scripting language for creating dynamic web sites
+URL         : http://www.php.net/
+License     : PHP and LGPLv2 and LGPLv2+
+Description : PHP is an HTML-embedded scripting language.` },
+{ title: 'deb', content: 
+`apt-cache show alt-php73-cli\n
+Package: alt-php73-cli
+Source: php
+Version: 7.3.18-1
+Architecture: amd64
+Maintainer: Sergey Fokin <sfokin@cloudlinux.com>
+Installed-Size: 51694
+Depends: libbz2-1.0, libc6 (>= 2.14), libcurl3 (>= 7.44.0), libgmp10, libreadline6 (>= 6.0), libssl1.0.0 (>= 1.0.2~beta3), libsystemd0, libxml2 (>= 2.9.0), zlib1g (>= 1:1.1.4), alt-php73-common (= 7.3.18-1), libcurl4-openssl-dev, libnghttp2-14
+Homepage: http://www.php.net/
+Priority: optional
+Section: libs
+Filename: pool/main/p/php/alt-php73-cli_7.3.18-1_amd64.deb
+Size: 10247916
+SHA256: 6f107e60684695b6261871a5540c4742eb6e86befe767ab313d1eacda023e5bb
+SHA1: e8e7d6ab06470cbda5f5ef65a48c7c527ff52e9b
+MD5sum: d6c664d4f4b229c1e6727804888f6079
+Description: command-line interpreter for the PHP scripting language.
+Description-md5: 0d83f7bf7177d3376a59b73890c8494d` }
+]" />    
 
 **How to install packages:**
 


### PR DESCRIPTION
This pull request introduces improvements to enhance the user experience when working with code blocks and documentation navigation. 
* Code blocks now include a copy button to copy commands.
  * What SVGs to use? I used GitHub's
  * I couldn't manage to make code blocks like this by default, requires manually wrapping every time
* Added code tabs to allow more compact and structured instructions by combining related variants (e.g. rpm/deb based) in a single place.
  * Issue: I couldn't make code tabs to allow aligning them with the text, there seem to be sort of indentation issue inside code tabs. (screenshot 2)
  * What SVGs to use? I used GitHub's
* Breadcrumbs are now clickable, with support for parent, improving page navigation and context visibility.
  * Issue: It seems that extracting a heading for the breadcrumb from the file doesn't work for the parent level.

The code was written with the help of AI, so I’d appreciate a careful code review and general feedback on the code and the ideas behind these changes is welcome.

We could also consider upgrating vue to use and customize plugins: [copy-code](https://ecosystem.vuejs.press/plugins/features/copy-code.html), [tabs](https://theme-hope.vuejs.press/guide/markdown/code/code-tabs)

![tuxcare-feature-1](https://github.com/user-attachments/assets/b534cdde-092b-4fe6-b356-b936998c1e60)
![tuxcare-feature-2](https://github.com/user-attachments/assets/87782249-b6f0-4763-9c80-b87a219f97c5)
