### PR TITLE
docs: changes current output to exact output from terminal

### DIFF
--- a/docs/els-for-languages/angularjs/README.md
+++ b/docs/els-for-languages/angularjs/README.md
@@ -159,9 +159,9 @@ TuxCare provides ELS for AngularJS as an NPM package, hosted on a secure interna
   You will see an output like:
 
   ```text
-  changed 1 package, and audited 5 packages in 892ms
+  up to date, audited 2 packages in 551ms
 
-  2 vulnerabilities (1 moderate, 1 high)
+  1 high severity vulnerability
   ```
 
 * You've successfully integrated the TuxCare ELS for AngularJS repository into your project.


### PR DESCRIPTION
This modifies the example output in the AngularJS docs to what the terminal actually says with a fresh install of AngularJS v1.5 - v1.8, and following our guide step-by-step. The time it takes in `ms` will vary based on the user's speeds.

What the docs say currently:
```
changed 1 package, and audited 5 packages in 892ms

2 vulnerabilities (1 moderate, 1 high)
```

What the actual output is:
```
up to date, audited 2 packages in 551ms

1 high severity vulnerability
```