### PR TITLE
fix ELSSteps punctuation and standardize What's Next heading

### DIFF
--- a/docs/els-for-applications/apache-hadoop/README.md
+++ b/docs/els-for-applications/apache-hadoop/README.md
@@ -95,7 +95,7 @@ Our ELS for Apache Hadoop service is designed to provide solutions for organizat
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-applications/apache-hive/README.md
+++ b/docs/els-for-applications/apache-hive/README.md
@@ -95,7 +95,7 @@ Our ELS for Apache Hive service is designed to provide solutions for organizatio
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-applications/gradle/README.md
+++ b/docs/els-for-applications/gradle/README.md
@@ -69,7 +69,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Gradle provides security patches f
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-applications/grafana/README.md
+++ b/docs/els-for-applications/grafana/README.md
@@ -93,7 +93,7 @@ TuxCare provides ELS for Grafana as pre-built binaries for the following distrib
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-applications/loki/README.md
+++ b/docs/els-for-applications/loki/README.md
@@ -93,7 +93,7 @@ TuxCare provides ELS for Loki as pre-built binaries for the following distributi
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-applications/maven/README.md
+++ b/docs/els-for-applications/maven/README.md
@@ -70,7 +70,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Apache Maven provides security pat
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-applications/mysql-and-percona-server/README.md
+++ b/docs/els-for-applications/mysql-and-percona-server/README.md
@@ -59,7 +59,7 @@ To remove the MySQL ELS repository:
 sh install-mysql-els-repo.sh --delete
 ```
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/alpine-linux-3-18-els/README.md
+++ b/docs/els-for-os/alpine-linux-3-18-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/alpinelinux3.18-els/install-els-alpine-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-els-alpine-repo.sh --license-key XXXXXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    apk info els-alpine-release
@@ -52,7 +52,7 @@
 
  </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/amazon-linux-2-els/README.md
+++ b/docs/els-for-os/amazon-linux-2-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/amazonlinux2-els/install-amazonlinux2-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-amazonlinux2-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -38,7 +38,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/centos-6-els/README.md
+++ b/docs/els-for-os/centos-6-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.els.tuxcare.com/centos6-els/install-centos6-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-centos6-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -56,7 +56,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/centos-7-els/README.md
+++ b/docs/els-for-os/centos-7-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/centos7-els/install-centos7-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-centos7-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -57,7 +57,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/centos-8-els/README.md
+++ b/docs/els-for-os/centos-8-els/README.md
@@ -13,14 +13,14 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    <CodeTabs :tabs="[
      { title: 'CentOS 8.4 ELS', content: `wget https://repo.els.tuxcare.com/centos8.4-els/install-centos8.4-els-repo.sh` },
      { title: 'CentOS 8.5 ELS', content: `wget https://repo.els.tuxcare.com/centos8.5-els/install-centos8.5-els-repo.sh` }
    ]" />
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -29,7 +29,7 @@
      { title: 'CentOS 8.5 ELS', content: `sh install-centos8.5-els-repo.sh --license-key XXXXXXXXXXX` }
    ]" />
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -58,7 +58,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title :versions="['Centos-8.4', 'Centos-8.5']">
 

--- a/docs/els-for-os/centos-stream-8-els/README.md
+++ b/docs/els-for-os/centos-stream-8-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/centos8stream-els/install-centos8stream-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-centos8stream-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -56,7 +56,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/debian-10-els/README.md
+++ b/docs/els-for-os/debian-10-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/debian10-els/install-debian10-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    bash install-debian10-els-repo.sh --license-key XXXXXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    apt-cache show els-os-release
@@ -61,7 +61,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/oracle-linux-6-els/README.md
+++ b/docs/els-for-os/oracle-linux-6-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.els.tuxcare.com/oraclelinux6-els/install-oraclelinux6-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-oraclelinux6-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -53,7 +53,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/oracle-linux-7-els/README.md
+++ b/docs/els-for-os/oracle-linux-7-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/oraclelinux7-els/install-oraclelinux7-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-oraclelinux7-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -62,13 +62,13 @@
 The installation script **does not automatically add** the TuxCare UEKR6 repository. If you plan to use the `kernel-uek` package on your Oracle Linux 7 system, you need to enable the TuxCare UEKR6 repository manually.
 <ELSSteps>
 
-1. Use an editor of your choice to edit the `/etc/yum.repos.d/oraclelinux7-els.repo` file:
+1. Use an editor of your choice to edit the `/etc/yum.repos.d/oraclelinux7-els.repo` file
 
    ```
    vi /etc/yum.repos.d/oraclelinux7-els.repo
    ```
 
-2. Add the following lines there to enable the TuxCare UEKR 6 repository:
+2. Add the following lines there to enable the TuxCare UEKR 6 repository
 
    ```
    [oraclelinux7-els-UEKR6]
@@ -78,7 +78,7 @@ The installation script **does not automatically add** the TuxCare UEKR6 reposit
    ```
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/red-hat-enterprise-linux-7-els/README.md
+++ b/docs/els-for-os/red-hat-enterprise-linux-7-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/rhel7-els/install-rhel7-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-rhel7-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -38,7 +38,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/red-hat-enterprise-linux-8-els/README.md
+++ b/docs/els-for-os/red-hat-enterprise-linux-8-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/rhel8-els/install-rhel8-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    sh install-rhel8-els-repo.sh --license-key XXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    yum info els-define
@@ -38,7 +38,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/ubuntu-16-04-els/README.md
+++ b/docs/els-for-os/ubuntu-16-04-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.els.tuxcare.com/ubuntu16_04-els/install-ubuntu16.04-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    bash install-ubuntu16.04-els-repo.sh --license-key XXX-XXXXXXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    apt-cache show els-define
@@ -59,7 +59,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/ubuntu-18-04-els/README.md
+++ b/docs/els-for-os/ubuntu-18-04-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.els.tuxcare.com/ubuntu18_04-els/install-ubuntu18.04-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    bash install-ubuntu18.04-els-repo.sh --license-key XXXXXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    apt-cache show els-define
@@ -59,7 +59,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-os/ubuntu-20-04-els/README.md
+++ b/docs/els-for-os/ubuntu-20-04-els/README.md
@@ -13,13 +13,13 @@
 
 <ELSSteps>
 
-1. Download the install script:
+1. Download the install script
 
    ```
    wget https://repo.tuxcare.com/ubuntu20_04-els/install-ubuntu20.04-els-repo.sh
    ```
 
-2. Run with your license key.
+2. Run with your license key
 
    The script registers the server in the CLN with the key, adds a PGP key to the server.
 
@@ -27,7 +27,7 @@
    bash install-ubuntu20.04-els-repo.sh --license-key XXXXXXXXXXX
    ```
 
-3. Verify that the installation was successful by running the following command:
+3. Verify that the installation was successful by running the following command
 
    ```
    apt-cache show els-os-release
@@ -61,7 +61,7 @@
 
 </ELSSteps>
 
-## What's next?
+## What's Next?
 
 <WhatsNext hide-title>
 

--- a/docs/els-for-runtimes/dotnet/README.md
+++ b/docs/els-for-runtimes/dotnet/README.md
@@ -261,7 +261,9 @@ The following steps use the .NET SDK installation as an example. If you are inst
 
   If you encounter conflicts, try uninstalling the previous version before installing the new one. In most cases, .NET versions can coexist without issues, but removing the older version may help resolve compatibility problems.
 
-<WhatsNext>
+## What's Next?
+
+<WhatsNext hide-title>
 
 * ![](/images/box.webp) [ELS NuGet Repository](/els-for-libraries/dotnet/) — Set up the TuxCare NuGet feed, install patched packages, and manage .NET package dependencies
 * ![](/images/book.webp) [Official .NET documentation](https://learn.microsoft.com/en-us/dotnet/fundamentals/) — Getting started guides, API reference, and platform fundamentals

--- a/docs/els-for-runtimes/nodejs/README.md
+++ b/docs/els-for-runtimes/nodejs/README.md
@@ -97,7 +97,9 @@ alt-nodejs provides a more flexible and convenient environment for working with 
 
 </ELSSteps>
 
-<WhatsNext>
+## What's Next?
+
+<WhatsNext hide-title>
 
 * ![](/images/shield.webp) [Machine-readable security data](../machine-readable-security-data/) — CSAF advisories and RSS feeds for Node.js ELS
 

--- a/docs/els-for-runtimes/php/README.md
+++ b/docs/els-for-runtimes/php/README.md
@@ -995,7 +995,9 @@ The PHP core includes many built-in extensions that provide basic functionality,
 
 </TableTabs>
 
-<WhatsNext>
+## What's Next?
+
+<WhatsNext hide-title>
 
 * ![](/images/shield.webp) [Machine-readable security data](../machine-readable-security-data/) — OVAL, CSAF, Errata, and RSS feeds for PHP ELS
 * ![](/images/clipboard-notes.webp) [PHP Changelog](https://changelog.cloudlinux.com/) — latest updates, fixes, and enhancements for ALT-PHP

--- a/docs/els-for-runtimes/python/README.md
+++ b/docs/els-for-runtimes/python/README.md
@@ -83,7 +83,9 @@ alt-python provides a more flexible and convenient environment for working with 
 
 </ELSSteps>
 
-<WhatsNext>
+## What's Next?
+
+<WhatsNext hide-title>
 
 * ![](/images/shield.webp) [Machine-readable security data](../machine-readable-security-data/) — OVAL, CSAF, Errata, and RSS feeds for Python ELS
 

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -87,7 +87,9 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 </ELSSteps>
 
-<WhatsNext>
+## What's Next?
+
+<WhatsNext hide-title>
 
 * ![](/images/shield.webp) [Machine-readable security data](../machine-readable-security-data/) — CSAF advisories and RSS feeds for Ruby ELS
 


### PR DESCRIPTION
- Remove trailing punctuation from ELSSteps step titles in els-for-os
- Normalize What's Next sections to use '## What's Next?' h2 heading with <WhatsNext hide-title> across els-for-os, els-for-runtimes, and els-for-applications
