### PR TITLE
elsdoc-204, expand ELS Ruby OS/version matrix and add APK install

### DIFF
--- a/docs/.vuepress/components/ELSRTechnology.vue
+++ b/docs/.vuepress/components/ELSRTechnology.vue
@@ -36,7 +36,7 @@
 
   <div class="txc-logos-list">
     <div class="heading text-center">
-      <h3>We Keep Your Runtimes Secure on Enterprise Linux, <br>Windows, and Debian-Based Operating Systems</h3>
+      <h3>We Keep Your Runtimes Secure on Enterprise Linux, Windows, <br>Debian-Based, and Alpine Linux Operating Systems</h3>
     </div>
 
     <div class="list">
@@ -125,6 +125,10 @@ const operatingSystems = [
   {
     name: "Ubuntu",
     icon: "/images/Ubuntu.webp",
+  },
+  {
+    name: "Alpine Linux",
+    icon: "/images/alpine-linux.webp",
   },
   {
     name: "Windows",

--- a/docs/.vuepress/components/ELSRTechnology.vue
+++ b/docs/.vuepress/components/ELSRTechnology.vue
@@ -91,7 +91,7 @@ const runtimes = [
   },
   {
     name: "Ruby",
-    versions: "2.6 | 2.7 | 3.0 | 3.1",
+    versions: "2.6 | 2.7 | 3.0 | 3.1 | 3.2",
     link: "./ruby/",
     icon: "/images/ruby.webp",
   },

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -22,15 +22,23 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 ## Supported OS and Ruby versions
 
-| Operating Systems                                            | Package Type | OS Version                         | Ruby versions        |
-| :----------------------------------------------------------: | :----------: | :--------------------------------: | :------------------: |
-| EL 7 (CentOS, CloudLinux, Oracle Linux, etc.)                | RPM          | 7.x                                | 2.6, 2.7, 3.0, 3.1   |
-| EL 8 (AlmaLinux, CentOS, CentOS Stream, CloudLinux, Oracle Linux, etc.) | RPM | 8.x                     | 2.6, 2.7, 3.0, 3.1   |
-| EL 9 (AlmaLinux, CentOS, CloudLinux, Oracle Linux, etc.)     | RPM          | 9.x                                | 2.6, 2.7, 3.0, 3.1   |
-| EL 10 (AlmaLinux, CloudLinux, Oracle Linux, etc.)            | RPM          | 10.x                               | 2.6, 2.7, 3.0, 3.1   |
-| Ubuntu                                                       | DEB          | 16.04, 18.04, 20.04, 22.04, 24.04  | 2.6, 2.7, 3.0, 3.1   |
-| Debian                                                       | DEB          | 10, 11, 12, 13                     | 2.6, 2.7, 3.0, 3.1   |
-| Alpine Linux                                                 | APK          | 3.22                               | 2.7, 3.0, 3.1        |
+| Operating Systems                                                        | Package Type | OS Version | Ruby versions                                                             |
+| :----------------------------------------------------------------------: | :----------: | :--------: | :-----------------------------------------------------------------------: |
+| EL 6 (CentOS, CloudLinux, Oracle Linux, etc.)                            | RPM          | 6.x        | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7                          |
+| EL 7 (CentOS, CloudLinux, Oracle Linux, etc.)                            | RPM          | 7.x        | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2           |
+| EL 8 (AlmaLinux, CentOS, CentOS Stream, CloudLinux, Oracle Linux, etc.)  | RPM          | 8.x        | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4 |
+| EL 9 (AlmaLinux, CentOS, CloudLinux, Oracle Linux, etc.)                 | RPM          | 9.x        | 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4                     |
+| EL 10 (AlmaLinux, CloudLinux, Oracle Linux, etc.)                        | RPM          | 10.x       | 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                |
+| Debian                                                                   | DEB          | 10         | 3.2, 3.3, 3.4, 4.0                                                        |
+| Debian                                                                   | DEB          | 11         | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                         |
+| Debian                                                                   | DEB          | 12         | 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                    |
+| Debian                                                                   | DEB          | 13         | 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                    |
+| Ubuntu                                                                   | DEB          | 16.04      | 3.2, 3.3, 3.4, 4.0                                                        |
+| Ubuntu                                                                   | DEB          | 18.04      | 3.2, 3.3, 3.4, 4.0                                                        |
+| Ubuntu                                                                   | DEB          | 20.04      | 3.2, 3.3, 3.4, 4.0                                                        |
+| Ubuntu                                                                   | DEB          | 22.04      | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                         |
+| Ubuntu                                                                   | DEB          | 24.04      | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                         |
+| Alpine Linux                                                             | APK          | 3.22       | 2.7, 3.0, 3.1                                                             |
 
 **Supported architectures:** x86_64 (64-bit); aarch64 on Alpine Linux
 

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -34,7 +34,7 @@ alt-ruby provides a more flexible and convenient environment for working with di
 | Ubuntu                                                                   | DEB          | 24.04      | 2.7, 3.0, 3.1, 3.2            |
 | Alpine Linux                                                             | APK          | 3.22       | 2.6, 2.7, 3.0, 3.1, 3.2       |
 
-**Supported architectures:** x86_64 (64-bit); aarch64 on Alpine Linux
+**Supported architectures:** x86_64 on all OSes; aarch64 on Alpine Linux in addition to x86_64
 
 <ContactSales text="Other distros and architectures available upon request. Contact sales@tuxcare.com for more information." />
 
@@ -85,11 +85,18 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 4. Verify the installation
 
-   `alt-ruby` versions are installed alongside the system default. To use a specific version:
+   Check that the binary exists and returns the expected version:
 
-   ```text
-   source /opt/alt/alt-ruby27/enable
+   ```bash
+   /opt/alt/<ruby-version>/bin/ruby -v
+   ```
+
+   Optionally, add it to `PATH` to use it as default:
+
+   ```bash
+   export PATH=/opt/alt/<ruby-version>/bin:$PATH
    ruby -v
+   which ruby
    ```
 
 5. Update packages

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -22,13 +22,17 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 ## Supported OS and Ruby versions
 
-| Operating Systems | Package Type | OS Version     |
-| :---------------: | :----------: | :------------: |
-| Debian            | DEB          | 12, 13         |
+| Operating Systems                                            | Package Type | OS Version                         | Ruby versions        |
+| :----------------------------------------------------------: | :----------: | :--------------------------------: | :------------------: |
+| EL 7 (CentOS, CloudLinux, Oracle Linux, etc.)                | RPM          | 7.x                                | 2.6, 2.7, 3.0, 3.1   |
+| EL 8 (AlmaLinux, CentOS, CentOS Stream, CloudLinux, Oracle Linux, etc.) | RPM | 8.x                     | 2.6, 2.7, 3.0, 3.1   |
+| EL 9 (AlmaLinux, CentOS, CloudLinux, Oracle Linux, etc.)     | RPM          | 9.x                                | 2.6, 2.7, 3.0, 3.1   |
+| EL 10 (AlmaLinux, CloudLinux, Oracle Linux, etc.)            | RPM          | 10.x                               | 2.6, 2.7, 3.0, 3.1   |
+| Ubuntu                                                       | DEB          | 16.04, 18.04, 20.04, 22.04, 24.04  | 2.6, 2.7, 3.0, 3.1   |
+| Debian                                                       | DEB          | 10, 11, 12, 13                     | 2.6, 2.7, 3.0, 3.1   |
+| Alpine Linux                                                 | APK          | 3.22                               | 2.7, 3.0, 3.1        |
 
-**Supported Ruby versions:** 2.6, 2.7, 3.0, 3.1
-
-**Supported architecture:** x86_64 (64-bit)
+**Supported architectures:** x86_64 (64-bit); aarch64 on Alpine Linux
 
 <ContactSales text="Other distros and architectures available upon request. Contact sales@tuxcare.com for more information." />
 
@@ -45,29 +49,37 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 1. Download the installer script
 
-   ```text
-   wget https://repo.alt.tuxcare.com/alt-ruby-els/install-els-alt-ruby-deb-repo.sh
-   ```
+   <CodeTabs :tabs="[
+     { title: 'RPM', content: `wget https://repo.alt.tuxcare.com/alt-ruby-els/install-els-alt-ruby-rpm-repo.sh` },
+     { title: 'DEB', content: `wget https://repo.alt.tuxcare.com/alt-ruby-els/install-els-alt-ruby-deb-repo.sh` },
+     { title: 'APK', content: `wget https://repo.alt.tuxcare.com/alt-ruby-els/install-els-alt-ruby-apk-repo.sh` }
+   ]" />
 
 2. Run the installer script with your license key
 
    The script registers the server with CLN, adds the PGP key and repository.
 
-   ```text
-   bash install-els-alt-ruby-deb-repo.sh --license-key XXX-XXXXXXXXXXXX
-   ```
+   <CodeTabs :tabs="[
+     { title: 'RPM', content: `sh install-els-alt-ruby-rpm-repo.sh --license-key XXX-XXXXXXXXXXXX` },
+     { title: 'DEB', content: `bash install-els-alt-ruby-deb-repo.sh --license-key XXX-XXXXXXXXXXXX` },
+     { title: 'APK', content: `sh install-els-alt-ruby-apk-repo.sh --license-key XXX-XXXXXXXXXXXX` }
+   ]" />
 
 3. Install a Ruby version
 
-   ```text
-   apt-get install alt-ruby27
-   ```
+   <CodeTabs :tabs="[
+     { title: 'RPM', content: `yum install alt-ruby27` },
+     { title: 'DEB', content: `apt-get install alt-ruby27` },
+     { title: 'APK', content: `apk add alt-ruby27` }
+   ]" />
 
    To see available packages:
 
-   ```text
-   apt list -a | grep alt-ruby
-   ```
+   <CodeTabs :tabs="[
+     { title: 'RPM', content: `yum list available 'alt-ruby*'` },
+     { title: 'DEB', content: `apt list -a | grep alt-ruby` },
+     { title: 'APK', content: `apk search alt-ruby` }
+   ]" />
 
 4. Verify the installation
 
@@ -80,10 +92,11 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 5. Update packages
 
-   ```text
-   apt-get update
-   apt-get --only-upgrade install alt-ruby*
-   ```
+   <CodeTabs :tabs="[
+     { title: 'RPM', content: `yum update 'alt-ruby*'` },
+     { title: 'DEB', content: `apt-get update && apt-get --only-upgrade install 'alt-ruby*'` },
+     { title: 'APK', content: `apk update && apk upgrade 'alt-ruby*'` }
+   ]" />
 
 </ELSSteps>
 

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -22,23 +22,17 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 ## Supported OS and Ruby versions
 
-| Operating Systems                                                        | Package Type | OS Version | Ruby versions                                                             |
-| :----------------------------------------------------------------------: | :----------: | :--------: | :-----------------------------------------------------------------------: |
-| EL 6 (CentOS, CloudLinux, Oracle Linux, etc.)                            | RPM          | 6.x        | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7                          |
-| EL 7 (CentOS, CloudLinux, Oracle Linux, etc.)                            | RPM          | 7.x        | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2           |
-| EL 8 (AlmaLinux, CentOS, CentOS Stream, CloudLinux, Oracle Linux, etc.)  | RPM          | 8.x        | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4 |
-| EL 9 (AlmaLinux, CentOS, CloudLinux, Oracle Linux, etc.)                 | RPM          | 9.x        | 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4                     |
-| EL 10 (AlmaLinux, CloudLinux, Oracle Linux, etc.)                        | RPM          | 10.x       | 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                |
-| Debian                                                                   | DEB          | 10         | 3.2, 3.3, 3.4, 4.0                                                        |
-| Debian                                                                   | DEB          | 11         | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                         |
-| Debian                                                                   | DEB          | 12         | 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                    |
-| Debian                                                                   | DEB          | 13         | 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                    |
-| Ubuntu                                                                   | DEB          | 16.04      | 3.2, 3.3, 3.4, 4.0                                                        |
-| Ubuntu                                                                   | DEB          | 18.04      | 3.2, 3.3, 3.4, 4.0                                                        |
-| Ubuntu                                                                   | DEB          | 20.04      | 3.2, 3.3, 3.4, 4.0                                                        |
-| Ubuntu                                                                   | DEB          | 22.04      | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                         |
-| Ubuntu                                                                   | DEB          | 24.04      | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0                                         |
-| Alpine Linux                                                             | APK          | 3.22       | 2.7, 3.0, 3.1                                                             |
+| Operating Systems                                                        | Package Type | OS Version | Ruby versions                 |
+| :----------------------------------------------------------------------: | :----------: | :--------: | :---------------------------: |
+| EL 8 (AlmaLinux, CentOS, CentOS Stream, CloudLinux, Oracle Linux, etc.)  | RPM          | 8.x        | 2.7, 3.0, 3.1, 3.2            |
+| EL 9 (AlmaLinux, CentOS, CloudLinux, Oracle Linux, etc.)                 | RPM          | 9.x        | 2.7, 3.0, 3.1, 3.2            |
+| EL 10 (AlmaLinux, CloudLinux, Oracle Linux, etc.)                        | RPM          | 10.x       | 2.7, 3.0, 3.1, 3.2            |
+| Debian                                                                   | DEB          | 11         | 2.7, 3.0, 3.1, 3.2            |
+| Debian                                                                   | DEB          | 12         | 2.6, 2.7, 3.0, 3.1, 3.2       |
+| Debian                                                                   | DEB          | 13         | 2.6, 2.7, 3.0, 3.1, 3.2       |
+| Ubuntu                                                                   | DEB          | 22.04      | 2.7, 3.0, 3.1, 3.2            |
+| Ubuntu                                                                   | DEB          | 24.04      | 2.7, 3.0, 3.1, 3.2            |
+| Alpine Linux                                                             | APK          | 3.22       | 2.6, 2.7, 3.0, 3.1, 3.2       |
 
 **Supported architectures:** x86_64 (64-bit); aarch64 on Alpine Linux
 
@@ -112,6 +106,9 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
 <WhatsNext hide-title>
 
+* ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Ruby) — Track vulnerability fixes and updates
+* ![](/images/shield.webp) [Available fixes](https://tuxcare.com/cve-tracker/fixes?product=Ruby) — Patched versions and changelogs
+* ![](/images/clipboard-notes.webp) [Supported components](https://tuxcare.com/cve-tracker/products?product=Ruby) — Full list of product parts covered by ELS
 * ![](/images/shield.webp) [Machine-readable security data](../machine-readable-security-data/) — CSAF advisories and RSS feeds for Ruby ELS
 
 </WhatsNext>

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -87,13 +87,13 @@ alt-ruby provides a more flexible and convenient environment for working with di
 
    Check that the binary exists and returns the expected version:
 
-   ```bash
+   ```text
    /opt/alt/<ruby-version>/bin/ruby -v
    ```
 
    Optionally, add it to `PATH` to use it as default:
 
-   ```bash
+   ```text
    export PATH=/opt/alt/<ruby-version>/bin:$PATH
    ruby -v
    which ruby


### PR DESCRIPTION
Document all alt-ruby supported OSes (EL 7-10, Ubuntu 16.04-24.04, Debian 10-13, Alpine 3.22) with their Ruby versions, and add a unified RPM/DEB/APK installation guide via CodeTabs. Include Alpine Linux in the runtimes OS list in ELSRTechnology.vue.