### PR TITLE
fix(docs): correct SBOM/VEX terminology in ELS overview pages

### DIFF
--- a/docs/els-for-applications/README.md
+++ b/docs/els-for-applications/README.md
@@ -37,7 +37,7 @@ TuxCare's commitment to transparency and visibility is foundational to our ELS f
 Note: SBOM support for certain components is in progress and will be available soon. To confirm current availability or expected timeframes, please contact [sales@tuxcare.com](mailto:sales@tuxcare.com).
 :::
 
-* **Enhanced Metadata in Standard Formats:** Each SBOM is provided in universally recognized formats such as SPDX and VEX. These include enhanced metadata like artifact analysis, package health, and vulnerability impact data, ensuring that you have the most detailed and actionable information at your fingertips.
+* **Enhanced Metadata in Standard Formats:** SBOMs are provided in SPDX and CycloneDX. CycloneDX VEX documents accompany them with exploitability status (`affected`, `not_affected`, `fixed`, `under_investigation`) so scanners can suppress non-applicable findings.
 * **Verifiable Integrity and Provenance**: Our packages and metadata provide comprehensive end-to-end provenance, detailing how each package was constructed and tested, ensuring that all components in your software stack are trustworthy.
 
 :::warning

--- a/docs/els-for-libraries/README.md
+++ b/docs/els-for-libraries/README.md
@@ -37,7 +37,7 @@ TuxCare's commitment to transparency and visibility is foundational to our ELS f
 Note: SBOM support for certain components is in progress and will be available soon. To confirm current availability or expected timeframes, please contact [sales@tuxcare.com](mailto:sales@tuxcare.com).
 :::
 
-* **Enhanced Metadata in Standard Formats:** Each SBOM is provided in universally recognized formats such as SPDX and VEX. These include enhanced metadata like artifact analysis, package health, and vulnerability impact data, ensuring that you have the most detailed and actionable information at your fingertips.
+* **Enhanced Metadata in Standard Formats:** SBOMs are provided in SPDX and CycloneDX. CycloneDX VEX documents accompany them with exploitability status (`affected`, `not_affected`, `fixed`, `under_investigation`) so scanners can suppress non-applicable findings.
 * **Verifiable Integrity and Provenance**: Our packages and metadata provide comprehensive end-to-end provenance, detailing how each package was constructed and tested, ensuring that all components in your software stack are trustworthy.
 
 :::warning

--- a/docs/els-for-runtimes/README.md
+++ b/docs/els-for-runtimes/README.md
@@ -39,7 +39,7 @@ TuxCare's commitment to transparency and visibility is foundational to our ELS f
 Note: SBOM support for certain components is in progress and will be available soon. To confirm current availability or expected timeframes, please contact [sales@tuxcare.com](mailto:sales@tuxcare.com).
 :::
 
-* **Enhanced Metadata in Standard Formats:** Each SBOM is provided in universally recognized formats such as SPDX and VEX. These include enhanced metadata like artifact analysis, package health, and vulnerability impact data, ensuring that you have the most detailed and actionable information at your fingertips.
+* **Enhanced Metadata in Standard Formats:** SBOMs are provided in SPDX and CycloneDX. CycloneDX VEX documents accompany them with exploitability status (`affected`, `not_affected`, `fixed`, `under_investigation`) so scanners can suppress non-applicable findings.
 * **Verifiable Integrity and Provenance**: Our packages and metadata provide comprehensive end-to-end provenance, detailing how each package was constructed and tested, ensuring that all components in your software stack are trustworthy.
 
 :::warning


### PR DESCRIPTION
VEX is not an SBOM format; SBOMs are SPDX and CycloneDX, and VEX is a companion document conveying exploitability status. Update the three "Enhanced Metadata in Standard Formats" bullets to reflect what the pipeline actually emits (SPDX + CycloneDX, with CycloneDX VEX).

Refs ELSDOC-274.