### PR TITLE
docs(els): drop hard-coded CVSS version from landing pages

### DIFF
--- a/docs/els-for-applications/README.md
+++ b/docs/els-for-applications/README.md
@@ -6,7 +6,7 @@
 
 ## Vulnerability Coverage and Target Response Times
 
-TuxCare employs the Common Vulnerability Scoring System (CVSS v3.1) to assess the severity of security vulnerabilities. Our severity rating system for patching vulnerabilities integrates both NVD scoring and vendor scoring (when available). When the vendor's score is lower than the NVD score, we prioritize the NVD score.
+TuxCare employs the Common Vulnerability Scoring System (CVSS) to assess the severity of security vulnerabilities. Our severity rating system integrates both NVD scoring and vendor scoring (when available); when the vendor's score is lower than the NVD score, we prioritize the NVD score.
 
 Aligning with many industry standards and regulatory requirements, TuxCare is committed to delivering timely security updates. For instance, the Payment Card Industry Data Security Standard (PCI DSS) mandates that all 'High' vulnerabilities (CVSS score of 7.0+) must be addressed within 30 days. Other regulations and standards, such as the Health Insurance Portability and Accountability Act (HIPAA) for healthcare or the Federal Information Security Management Act (FISMA) for government agencies, uphold similar requirements.
 

--- a/docs/els-for-libraries/README.md
+++ b/docs/els-for-libraries/README.md
@@ -6,7 +6,7 @@
 
 ## Vulnerability Coverage and Target Response Times
 
-TuxCare employs the Common Vulnerability Scoring System (CVSS v3.1) to assess the severity of security vulnerabilities. Our severity rating system for patching vulnerabilities integrates both NVD scoring and vendor scoring (when available). When the vendor's score is lower than the NVD score, we prioritize the NVD score.
+TuxCare employs the Common Vulnerability Scoring System (CVSS) to assess the severity of security vulnerabilities. Our severity rating system integrates both NVD scoring and vendor scoring (when available); when the vendor's score is lower than the NVD score, we prioritize the NVD score.
 
 Aligning with many industry standards and regulatory requirements, TuxCare is committed to delivering timely security updates. For instance, the Payment Card Industry Data Security Standard (PCI DSS) mandates that all 'High' vulnerabilities (CVSS score of 7.0+) must be addressed within 30 days. Other regulations and standards, such as the Health Insurance Portability and Accountability Act (HIPAA) for healthcare or the Federal Information Security Management Act (FISMA) for government agencies, uphold similar requirements.
 

--- a/docs/els-for-os/README.md
+++ b/docs/els-for-os/README.md
@@ -20,7 +20,7 @@ It delivers 24/7/365 access to TuxCare’s support team through the [TuxCare Sup
 
 ## Vulnerability coverage
 
-TuxCare employs the Common Vulnerability Scoring System (CVSS v3) to assess the severity of security vulnerabilities. Our severity rating system for patching vulnerabilities integrates both NVD scoring and vendor scoring (when available). When the vendor's score is lower than the NVD score, we give priority to the NVD score.
+TuxCare employs the Common Vulnerability Scoring System (CVSS) to assess the severity of security vulnerabilities. Our severity rating system integrates both NVD scoring and vendor scoring (when available); when the vendor's score is lower than the NVD score, we prioritize the NVD score.
 
 TuxCare shall provide security patches for high- and critical-risk vulnerabilities (CVSS 7 and above). For medium-risk vulnerabilities (CVSS 4.0 to 6.9), TuxCare may provide security patches where mitigations are not available, and there is sufficient customer demand. TuxCare reserves the right to offer a mitigation strategy as an alternative to a direct code fix.
 

--- a/docs/els-for-runtimes/README.md
+++ b/docs/els-for-runtimes/README.md
@@ -8,7 +8,7 @@
 
 ## Vulnerability Coverage and Target Response Times
 
-TuxCare employs the Common Vulnerability Scoring System (CVSS v3.1) to assess the severity of security vulnerabilities. Our severity rating system for patching vulnerabilities integrates both NVD scoring and vendor scoring (when available). When the vendor's score is lower than the NVD score, we prioritize the NVD score.
+TuxCare employs the Common Vulnerability Scoring System (CVSS) to assess the severity of security vulnerabilities. Our severity rating system integrates both NVD scoring and vendor scoring (when available); when the vendor's score is lower than the NVD score, we prioritize the NVD score.
 
 Aligning with many industry standards and regulatory requirements, TuxCare is committed to delivering timely security updates. For instance, the Payment Card Industry Data Security Standard (PCI DSS) mandates that all 'High' vulnerabilities (CVSS score of 7.0+) must be addressed within 30 days. Other regulations and standards, such as the Health Insurance Portability and Accountability Act (HIPAA) for healthcare or the Federal Information Security Management Act (FISMA) for government agencies, uphold similar requirements.
 

--- a/docs/enterprise-support-for-almalinux/README.md
+++ b/docs/enterprise-support-for-almalinux/README.md
@@ -36,7 +36,7 @@ Extended Security Updates are currently available for AlmaLinux 9.2, AlmaLinux 9
 
 ### Vulnerability coverage
 
-TuxCare employs the Common Vulnerability Scoring System (CVSS v3) to assess the severity of security vulnerabilities. Our severity rating system for patching vulnerabilities integrates both NVD scoring and vendor scoring (when available). When the vendor's score is lower than the NVD score, we give priority to the NVD score.
+TuxCare employs the Common Vulnerability Scoring System (CVSS) to assess the severity of security vulnerabilities. Our severity rating system integrates both NVD scoring and vendor scoring (when available); when the vendor's score is lower than the NVD score, we prioritize the NVD score.
 
 ESU prioritises security patches for High and Critical CVE's and bug fixes - but to help our customers comply with regulations such as FedRAMP, HIPAA and PCI-DSS - TuxCare also provides Low and Moderate severity security patches where possible (or otherwise mitigations/analysis) and where breaking changes aren't introduced, going back as far as November 2025. Additional Low/Moderate CVE patches can be purchased if required - speak to your Account Manager about our 10 CVE bundles.
 


### PR DESCRIPTION
CVSS v4.0 is the current standard (FIRST, Nov 2023) and NVD now publishes v4.0 scores alongside v3.1. Removes the version qualifier from the shared "Vulnerability Coverage" paragraph on the four ELS landing pages plus the AlmaLinux page so the wording stops aging. Severity thresholds are unchanged (v3.1 and v4.0 share qualitative bands), and the paragraph is now identical across pages.

ELSDOC-275