### PR TITLE
TCR-881 (docs: clarify KernelCare Plus legacy status and successor offering)

### DIFF
--- a/docs/live-patching-services/README.md
+++ b/docs/live-patching-services/README.md
@@ -679,6 +679,10 @@ The alternate feed option is enabled by setting the `PREFIX` variable in `/et
 
 ## KernelCare Enterprise
 
+:::tip Note
+**KernelCare Plus** was the former name for this product. It reached end-of-life in March 2023 and was replaced by **KernelCare Enterprise**, which is the current supported offering. KernelCare Enterprise includes everything KernelCare Plus provided, plus additional enterprise capabilities such as controlled patch rollout via ePortal, air-gapped environment support, and access to add-ons such as LibCare and QEMUCare. If you see references to "KernelCare Plus" on invoices or in the CLN portal, these refer to the same product now marketed as KernelCare Enterprise.
+:::
+
 KernelCare Enterprise live patching enhances customers' vulnerability patching programs by providing live patches to the Linux kernel and, optionally (with an add-on), to critical userspace components. The systems are patched according to your patch deployment policy, allowing you to customize your patch management to align with the needs of your unique environment, whether online or air-gapped.
 
 KernelCare Enterprise can be extended with the following add-ons:


### PR DESCRIPTION
## Summary
This PR adds a clarification note to the KernelCare Enterprise section in the live-patching services documentation. It outlines the relationship between the legacy KernelCare Plus product and the current KernelCare Enterprise offering.

## Motivation
A customer raised feedback (Support Ticket #282343) regarding confusion between KernelCare Plus and KernelCare Enterprise. The legacy product ("KernelCare Plus") reached EOL in March 2023, but because the old name still appears on some customer invoices and within the CLN portal, it was causing confusion for both customers and support staff.

Since the documentation had no mentions of "KernelCare Plus", there was no official resource resolving this naming discrepancy.

## Changes
* Added a :::tip Note callout block under the ## KernelCare Enterprise heading in docs/live-patching-services/README.md.
* Explicitly states that KernelCare Plus is the legacy/former name which reached EOL in March 2023.
* Clarifies that KernelCare Enterprise is the direct replacement covering the same scope plus new capabilities (ePortal, LibCare/QEMUCare, air-gapped support).
* Explains that references to "KernelCare Plus" on invoices/CLN point to the same product currently marketed as KernelCare Enterprise.