### PR TITLE
docs(els-runtimes): add ARM64 architecture coverage

### DIFF
--- a/docs/els-for-runtimes/nodejs/README.md
+++ b/docs/els-for-runtimes/nodejs/README.md
@@ -37,7 +37,7 @@ alt-nodejs provides a more flexible and convenient environment for working with 
 **Supported architectures:**
 
 * x86_64 — all supported OSes
-* ARM64 — Debian 12 and 13
+* aarch64/arm64 — Debian 12 and 13
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/nodejs/README.md
+++ b/docs/els-for-runtimes/nodejs/README.md
@@ -37,7 +37,7 @@ alt-nodejs provides a more flexible and convenient environment for working with 
 **Supported architectures:**
 
 * x86_64 — all supported OSes
-* aarch64/arm64 — Debian 12 and 13
+* arm64 — Debian 12 and 13
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/nodejs/README.md
+++ b/docs/els-for-runtimes/nodejs/README.md
@@ -34,7 +34,10 @@ alt-nodejs provides a more flexible and convenient environment for working with 
 | Debian                                                       | DEB          | 13                                | 12, 14, 16, 18, 20, 22, 23, 24    |
 | Alpine Linux                                                 | APK          | 3.22, 3.23                        | 12, 14, 16, 18, 20, 22, 23, 24    |
 
-**Supported architectures:** x86_64 (64-bit) on all supported OSes; arm64 on Debian 12 and 13 (in addition to x86_64).
+**Supported architectures:**
+
+* x86_64 — all supported OSes
+* ARM64 — Debian 12 and 13
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/nodejs/README.md
+++ b/docs/els-for-runtimes/nodejs/README.md
@@ -34,7 +34,7 @@ alt-nodejs provides a more flexible and convenient environment for working with 
 | Debian                                                       | DEB          | 13                                | 12, 14, 16, 18, 20, 22, 23, 24    |
 | Alpine Linux                                                 | APK          | 3.22, 3.23                        | 12, 14, 16, 18, 20, 22, 23, 24    |
 
-**Supported architecture:** x86_64 (64-bit)
+**Supported architectures:** x86_64 (64-bit) on all supported OSes; arm64 on Debian 12 and 13 (in addition to x86_64).
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/php/README.md
+++ b/docs/els-for-runtimes/php/README.md
@@ -39,7 +39,7 @@ alt-php provides a more flexible and convenient environment for working with dif
 | Alpine Linux                                                             | APK          | 3.22, 3.23                        | 7.3, 7.4, 8.0, 8.1                                                        |
 | Windows                                                                  | -            | Windows Server 2019, 2022, 2025   | 5.2, 5.4, 5.6, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2                               |
 
-**Supported architecture:** x86_64 (64-bit) on Linux
+**Supported architectures:** x86_64 (64-bit) on all supported OSes; arm64 on Debian 12 and 13; aarch64 on Alpine Linux 3.22+ (in addition to x86_64). On Windows, x64 and x86 are available.
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/php/README.md
+++ b/docs/els-for-runtimes/php/README.md
@@ -41,8 +41,9 @@ alt-php provides a more flexible and convenient environment for working with dif
 
 **Supported architectures:**
 
-* x86_64 — all supported Linux OSes; x64 and x86 on Windows
+* x86_64 — all supported Linux OSes
 * ARM64 — Debian 12 and 13, Alpine Linux 3.22 and later
+* Windows — x64 (64-bit) and x86 (32-bit) builds
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/php/README.md
+++ b/docs/els-for-runtimes/php/README.md
@@ -42,7 +42,7 @@ alt-php provides a more flexible and convenient environment for working with dif
 **Supported architectures:**
 
 * x86_64 — all supported Linux OSes; x64 and x86 on Windows
-* ARM64 — Debian 12 and 13, Alpine Linux 3.22+
+* ARM64 — Debian 12 and 13, Alpine Linux 3.22 and later
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/php/README.md
+++ b/docs/els-for-runtimes/php/README.md
@@ -39,7 +39,10 @@ alt-php provides a more flexible and convenient environment for working with dif
 | Alpine Linux                                                             | APK          | 3.22, 3.23                        | 7.3, 7.4, 8.0, 8.1                                                        |
 | Windows                                                                  | -            | Windows Server 2019, 2022, 2025   | 5.2, 5.4, 5.6, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2                               |
 
-**Supported architectures:** x86_64 (64-bit) on all supported OSes; arm64 on Debian 12 and 13; aarch64 on Alpine Linux 3.22+ (in addition to x86_64). On Windows, x64 and x86 are available.
+**Supported architectures:**
+
+* x86_64 — all supported Linux OSes; x64 and x86 on Windows
+* ARM64 — Debian 12 and 13, Alpine Linux 3.22+
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/php/README.md
+++ b/docs/els-for-runtimes/php/README.md
@@ -42,7 +42,7 @@ alt-php provides a more flexible and convenient environment for working with dif
 **Supported architectures:**
 
 * x86_64 — all supported Linux OSes
-* ARM64 — Debian 12 and 13, Alpine Linux 3.22 and later
+* aarch64/arm64 — Debian 12 and 13, Alpine Linux 3.22 and later
 * Windows — x64 (64-bit) and x86 (32-bit) builds
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />

--- a/docs/els-for-runtimes/python/README.md
+++ b/docs/els-for-runtimes/python/README.md
@@ -33,7 +33,10 @@ alt-python provides a more flexible and convenient environment for working with 
 | Debian                                                       | DEB          | 12, 13                             | 2.7, 3.6, 3.7, 3.8, 3.9       |
 | Alpine Linux                                                 | APK          | 3.22, 3.23                         | 3.6, 3.7, 3.8, 3.9            |
 
-**Supported architectures:** x86_64 (64-bit) on all supported OSes; arm64 on Debian 12 and 13 (in addition to x86_64).
+**Supported architectures:**
+
+* x86_64 — all supported OSes
+* ARM64 — Debian 12 and 13
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/python/README.md
+++ b/docs/els-for-runtimes/python/README.md
@@ -36,7 +36,7 @@ alt-python provides a more flexible and convenient environment for working with 
 **Supported architectures:**
 
 * x86_64 — all supported OSes
-* ARM64 — Debian 12 and 13
+* aarch64/arm64 — Debian 12 and 13
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/python/README.md
+++ b/docs/els-for-runtimes/python/README.md
@@ -33,7 +33,7 @@ alt-python provides a more flexible and convenient environment for working with 
 | Debian                                                       | DEB          | 12, 13                             | 2.7, 3.6, 3.7, 3.8, 3.9       |
 | Alpine Linux                                                 | APK          | 3.22, 3.23                         | 3.6, 3.7, 3.8, 3.9            |
 
-**Supported architecture:** x86_64 (64-bit)
+**Supported architectures:** x86_64 (64-bit) on all supported OSes; arm64 on Debian 12 and 13 (in addition to x86_64).
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/python/README.md
+++ b/docs/els-for-runtimes/python/README.md
@@ -36,7 +36,7 @@ alt-python provides a more flexible and convenient environment for working with 
 **Supported architectures:**
 
 * x86_64 — all supported OSes
-* aarch64/arm64 — Debian 12 and 13
+* arm64 — Debian 12 and 13
 
 <ContactSales text="Other versions and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -34,7 +34,10 @@ alt-ruby provides a more flexible and convenient environment for working with di
 | Ubuntu                                                                   | DEB          | 24.04      | 2.7, 3.0, 3.1, 3.2            |
 | Alpine Linux                                                             | APK          | 3.22       | 2.6, 2.7, 3.0, 3.1, 3.2       |
 
-**Supported architectures:** x86_64 on all supported OSes; arm64 on Debian 12 and 13; aarch64 on Alpine Linux (in addition to x86_64).
+**Supported architectures:**
+
+* x86_64 — all supported OSes
+* ARM64 — Debian 12 and 13, Alpine Linux
 
 <ContactSales text="Other distros and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -34,7 +34,7 @@ alt-ruby provides a more flexible and convenient environment for working with di
 | Ubuntu                                                                   | DEB          | 24.04      | 2.7, 3.0, 3.1, 3.2            |
 | Alpine Linux                                                             | APK          | 3.22       | 2.6, 2.7, 3.0, 3.1, 3.2       |
 
-**Supported architectures:** x86_64 on all OSes; aarch64 on Alpine Linux in addition to x86_64
+**Supported architectures:** x86_64 on all supported OSes; arm64 on Debian 12 and 13; aarch64 on Alpine Linux (in addition to x86_64).
 
 <ContactSales text="Other distros and architectures available upon request. Contact sales@tuxcare.com for more information." />
 

--- a/docs/els-for-runtimes/ruby/README.md
+++ b/docs/els-for-runtimes/ruby/README.md
@@ -37,7 +37,7 @@ alt-ruby provides a more flexible and convenient environment for working with di
 **Supported architectures:**
 
 * x86_64 — all supported OSes
-* ARM64 — Debian 12 and 13, Alpine Linux
+* aarch64/arm64 — Debian 12 and 13, Alpine Linux
 
 <ContactSales text="Other distros and architectures available upon request. Contact sales@tuxcare.com for more information." />
 


### PR DESCRIPTION
Document the architectures shipped for ELS runtimes:
- alt-php, alt-python, alt-nodejs, alt-ruby on Debian 12/13 publish arm64
- alt-php on Alpine 3.22+ publishes aarch64 alongside x86_64