### PR TITLE
feat(docs): add deep-link anchors to prerequisites and steps

### DIFF
--- a/docs/.vuepress/components/ELSPrerequisites.vue
+++ b/docs/.vuepress/components/ELSPrerequisites.vue
@@ -1,13 +1,44 @@
 <template>
-  <div class="prereqs">
+  <div ref="rootRef" class="prereqs">
     <div class="prereqs-header">
-      <h4><slot name="title">Prerequisites</slot></h4>
+      <h4 ref="headingRef"><slot name="title">Prerequisites</slot></h4>
     </div>
     <div class="prereqs-body">
       <slot />
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { slugify, uniqueId, collectUsedIds } from '../utils/slugify';
+
+const rootRef = ref<HTMLElement | null>(null);
+const headingRef = ref<HTMLElement | null>(null);
+
+function anchorPrerequisites() {
+  const heading = headingRef.value;
+  if (!heading || heading.id) return;
+
+  const used = collectUsedIds();
+  const id = uniqueId(slugify(heading.textContent ?? '') || 'prerequisites', used);
+  heading.id = id;
+
+  const anchor = document.createElement('a');
+  anchor.className = 'header-anchor prereq-anchor';
+  anchor.setAttribute('href', `#${id}`);
+  anchor.setAttribute('aria-hidden', 'true');
+  anchor.setAttribute('tabindex', '-1');
+  anchor.textContent = '#';
+  // On the left of the heading wording, vertically aligned with it.
+  heading.insertBefore(anchor, heading.firstChild);
+}
+
+onMounted(() => {
+  // Run after VuePress has assigned heading ids.
+  setTimeout(anchorPrerequisites, 0);
+});
+</script>
 
 <style scoped>
 .prereqs {
@@ -16,6 +47,8 @@
   background: linear-gradient(135deg, #f8fbff 0%, #f0f7ff 100%);
   padding: 1.25rem 1.5rem;
   margin: 1.5rem 0;
+  /* Land below the fixed navbar when navigated to via the section anchor. */
+  scroll-margin-top: 6rem;
 }
 
 .prereqs-header h4 {
@@ -23,6 +56,36 @@
   font-size: 1rem;
   font-weight: 700;
   color: #1b1f27;
+}
+
+/* The anchor floats left at its natural position with a fixed width and a
+   minimal gap; the body list below is indented to match (see .prereqs-body).
+   font-size in rem (not em) keeps it identical to the ELSSteps anchor. */
+.prereqs-header h4 :deep(a.prereq-anchor) {
+  opacity: 0;
+  font-size: 1rem;
+  width: 0.7rem;
+  padding-right: 0;
+  margin-left: 0;
+  /* Match the heading's line-height and nudge down so the floated # starts at
+     the same level as the wording instead of riding above it. */
+  line-height: inherit;
+  margin-top: 0.1rem;
+  transition: opacity 0.15s ease;
+}
+
+.prereqs-header h4:hover {
+  cursor: pointer;
+}
+
+.prereqs-header h4:hover :deep(a.prereq-anchor) {
+  opacity: 1;
+}
+
+/* Indent the body by the anchor's reserved width so the list aligns with the
+   "Prerequisites" wording, which the floated anchor pushes right. */
+.prereqs-body {
+  padding-left: 0.7rem;
 }
 
 .prereqs-body :deep(ul) {

--- a/docs/.vuepress/components/ELSPrerequisites.vue
+++ b/docs/.vuepress/components/ELSPrerequisites.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="rootRef" class="prereqs">
     <div class="prereqs-header">
-      <h4 ref="headingRef"><slot name="title">Prerequisites</slot></h4>
+      <h4 ref="headingRef" :id="headingId"><slot name="title">Prerequisites</slot></h4>
     </div>
     <div class="prereqs-body">
       <slot />
@@ -11,22 +11,23 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import { slugify, uniqueId, collectUsedIds } from '../utils/slugify';
+
+// id is rendered server-side so the section anchor exists in the static HTML.
+// Override with <ELSPrerequisites id="..."> if a page has more than one block.
+const props = defineProps<{ id?: string }>();
+const headingId = props.id ?? 'prerequisites';
 
 const rootRef = ref<HTMLElement | null>(null);
 const headingRef = ref<HTMLElement | null>(null);
 
 function anchorPrerequisites() {
   const heading = headingRef.value;
-  if (!heading || heading.id) return;
-
-  const used = collectUsedIds();
-  const id = uniqueId(slugify(heading.textContent ?? '') || 'prerequisites', used);
-  heading.id = id;
+  if (!heading || heading.dataset.anchored) return;
+  heading.dataset.anchored = '1';
 
   const anchor = document.createElement('a');
   anchor.className = 'header-anchor prereq-anchor';
-  anchor.setAttribute('href', `#${id}`);
+  anchor.setAttribute('href', `#${heading.id}`);
   anchor.setAttribute('aria-hidden', 'true');
   anchor.setAttribute('tabindex', '-1');
   anchor.textContent = '#';
@@ -35,7 +36,6 @@ function anchorPrerequisites() {
 }
 
 onMounted(() => {
-  // Run after VuePress has assigned heading ids.
   setTimeout(anchorPrerequisites, 0);
 });
 </script>

--- a/docs/.vuepress/components/ELSSteps.vue
+++ b/docs/.vuepress/components/ELSSteps.vue
@@ -16,18 +16,23 @@ function anchorSteps() {
   const body = bodyRef.value;
   if (!body) return;
 
-  // Seed from ids already on the page so step anchors never collide with
-  // heading anchors or other <ELSSteps> blocks on the same page.
+  // Step ids are assigned at build time (els-structured-data markdown plugin).
+  // We only read them here to attach the visual affordances; slugify is a
+  // fallback for the rare case a build-time id is missing.
   const used = collectUsedIds();
 
   // Top-level steps only — leave nested sub-steps (ol ol > li) un-anchored.
   body.querySelectorAll<HTMLLIElement>(':scope > ol > li').forEach((li) => {
-    if (li.id) return; // already processed
+    if (li.dataset.anchored) return; // already decorated
+    li.dataset.anchored = '1';
 
     const titleEl = li.querySelector('p');
-    const title = titleEl?.textContent ?? li.textContent ?? '';
-    const id = uniqueId(slugify(title) || 'step', used);
-    li.id = id;
+    let id = li.id;
+    if (!id) {
+      const title = titleEl?.textContent ?? li.textContent ?? '';
+      id = uniqueId(slugify(title) || 'step', used);
+      li.id = id;
+    }
 
     const anchor = document.createElement('a');
     anchor.className = 'header-anchor els-step-anchor';

--- a/docs/.vuepress/components/ELSSteps.vue
+++ b/docs/.vuepress/components/ELSSteps.vue
@@ -1,10 +1,60 @@
 <template>
   <div class="els-steps">
-    <div class="els-steps-body">
+    <div ref="bodyRef" class="els-steps-body">
       <slot />
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { slugify, uniqueId, collectUsedIds } from '../utils/slugify';
+
+const bodyRef = ref<HTMLElement | null>(null);
+
+function anchorSteps() {
+  const body = bodyRef.value;
+  if (!body) return;
+
+  // Seed from ids already on the page so step anchors never collide with
+  // heading anchors or other <ELSSteps> blocks on the same page.
+  const used = collectUsedIds();
+
+  // Top-level steps only — leave nested sub-steps (ol ol > li) un-anchored.
+  body.querySelectorAll<HTMLLIElement>(':scope > ol > li').forEach((li) => {
+    if (li.id) return; // already processed
+
+    const titleEl = li.querySelector('p');
+    const title = titleEl?.textContent ?? li.textContent ?? '';
+    const id = uniqueId(slugify(title) || 'step', used);
+    li.id = id;
+
+    const anchor = document.createElement('a');
+    anchor.className = 'header-anchor els-step-anchor';
+    anchor.setAttribute('href', `#${id}`);
+    anchor.setAttribute('aria-hidden', 'true');
+    anchor.setAttribute('tabindex', '-1');
+    anchor.textContent = '#';
+    // On the left of the step title (prepended), vertically aligned with it.
+    const target = titleEl ?? li;
+    target.insertBefore(anchor, target.firstChild);
+
+    // Transparent overlay over the number badge so clicking the number also
+    // navigates to the step's anchor and updates the URL.
+    const numberLink = document.createElement('a');
+    numberLink.className = 'els-step-number';
+    numberLink.setAttribute('href', `#${id}`);
+    numberLink.setAttribute('aria-hidden', 'true');
+    numberLink.setAttribute('tabindex', '-1');
+    li.appendChild(numberLink);
+  });
+}
+
+onMounted(() => {
+  // Run after VuePress has assigned heading ids.
+  setTimeout(anchorSteps, 0);
+});
+</script>
 
 <style scoped>
 .els-steps {
@@ -22,11 +72,52 @@
 .els-steps-body :deep(ol > li) {
   counter-increment: step-counter;
   position: relative;
-  padding-left: 1.5rem;
+  padding-left: 1.2rem;
   padding-bottom: 1.25rem;
   margin-bottom: 0;
   border-left: 2px solid #e0e3e8;
   margin-left: 0.9rem;
+  /* Land below the fixed navbar when navigated to via a step anchor. */
+  scroll-margin-top: 6rem;
+}
+
+/* The anchor floats left at its natural position (no negative margin, so it
+   never overlaps the number badge), with a fixed width and a minimal gap.
+   font-size in rem (not em) keeps it identical to the prerequisites anchor. */
+.els-steps-body :deep(ol > li > p:first-child > a.els-step-anchor) {
+  opacity: 0;
+  font-size: 1rem;
+  width: 0.7rem;
+  padding-right: 0;
+  margin-left: 0;
+  /* Inherit the title's 2rem line-height so the floated # centers at the same
+     level as the (vertically centered) wording. No extra margin-top needed. */
+  line-height: inherit;
+  margin-top: 0;
+  transition: opacity 0.15s ease;
+}
+
+.els-steps-body :deep(ol > li:hover > p:first-child > a.els-step-anchor) {
+  opacity: 1;
+}
+
+/* Indent the step's body content (everything below the title) by the anchor's
+   reserved width so it aligns with the title wording. margin-left (not padding)
+   so code blocks move as a whole and their background aligns too. Exclude the
+   absolutely positioned number-overlay link. */
+.els-steps-body :deep(ol > li > *:not(:first-child):not(a)) {
+  margin-left: 0.7rem;
+}
+
+/* Transparent overlay over the number badge — makes the number clickable. */
+.els-steps-body :deep(ol > li > a.els-step-number) {
+  position: absolute;
+  left: -1rem;
+  top: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  cursor: pointer;
 }
 
 .els-steps-body :deep(ol > li:last-child) {
@@ -50,12 +141,22 @@
   align-items: center;
   justify-content: center;
   line-height: 1;
+  transition: background 0.15s ease;
+}
+
+/* Hover hint on the step: the number badge changes color. */
+.els-steps-body :deep(ol > li:hover::before) {
+  background: #0B5CAD;
 }
 
 .els-steps-body :deep(ol > li > p:first-child) {
   font-weight: 600;
   color: #0d1a26;
   margin-top: 0;
+  /* Match the number badge height so the wording sits at the badge's vertical
+     middle (where the number is) instead of at its top. */
+  min-height: 2rem;
+  line-height: 2rem;
 }
 
 .els-steps-body :deep(ol > li > p) {
@@ -83,7 +184,10 @@
 
 .els-steps-body :deep(div[class*="language-"]),
 .els-steps-body :deep(.code-with-copy) {
-  margin: 0.5rem 0;
+  /* top/bottom only — left indent comes from the body-content rule above so
+     the code block aligns with the step wording. */
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .els-steps-body :deep(:not(pre) > code) {

--- a/docs/.vuepress/config-user/plugins.ts
+++ b/docs/.vuepress/config-user/plugins.ts
@@ -3,9 +3,11 @@ import {ContainerPluginOptions} from "@vuepress/plugin-container/lib/node/contai
 import { registerComponentsPlugin } from '@vuepress/plugin-register-components'
 import { prismjsPlugin } from '@vuepress/plugin-prismjs'
 import { path } from '@vuepress/utils'
+import { elsStructuredDataPlugin } from '../plugins/elsStructuredData'
 
 export default [
     prismjsPlugin(),
+    elsStructuredDataPlugin,
     containerPlugin({
         type: 'warning',
         before: info => `<div class="warning custom-block"><p class="custom-block-title">${info}</p>`,

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -2,17 +2,14 @@ import { defineUserConfig, viteBundler } from "vuepress";
 import theme from "./theme";
 import plugins from "./config-user/plugins";
 import headFunctions from "./headFunctions";
+import { slugify } from "./utils/slugify";
 
 export default defineUserConfig({
   theme,
   markdown: {
     anchor: {
-    slugify: str =>
-      str
-        .replace(/®/g, '')
-        .replace(/™/g, '')
-        .toLowerCase()
-        .replace(/\s+/g, '-')
+      // Shared rule: strip punctuation/signs (, . ? ! ' etc.) from anchor urls.
+      slugify,
     },
     headers: {
       level: [2, 3, 4, 5],

--- a/docs/.vuepress/plugins/elsStructuredData.ts
+++ b/docs/.vuepress/plugins/elsStructuredData.ts
@@ -1,0 +1,124 @@
+import { slugify } from "../utils/slugify";
+
+/**
+ * Build-time structured data for <ELSSteps> blocks.
+ *
+ *   1. extendsMarkdown: assigns a stable, page-unique `id` (slug of the step
+ *      title) to each top-level step <li>, so the anchor is present in the SSR
+ *      HTML (machine-addressable), not only after the client-side script runs.
+ *   2. extendsPage: emits a schema.org HowTo / HowToStep JSON-LD <script> into
+ *      the page <head> (the correct place for JSON-LD; injecting a <script>
+ *      into the page body breaks VuePress's SFC compilation).
+ *
+ * Both paths slug the same step titles with the same page-wide dedup, so the
+ * JSON-LD `url` matches the `<li id>` in the HTML.
+ */
+
+function clean(s: string): string {
+  return (s || "")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\*\*([^*]*)\*\*/g, "$1")
+    .replace(/\*([^*]*)\*/g, "$1")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// First inline text inside a list item = the step title.
+function firstInlineText(tokens: any[], openIdx: number): string {
+  for (let j = openIdx + 1; j < tokens.length; j++) {
+    if (tokens[j].type === "inline") return tokens[j].content;
+    if (tokens[j].type === "list_item_close") break;
+  }
+  return "";
+}
+
+// ---- point 1: assign ids to step <li> at parse time ----
+function assignStepIds(md: any) {
+  md.core.ruler.push("els_step_ids", (state: any) => {
+    const tokens = state.tokens;
+    const used = new Set<string>();
+    let inSteps = 0;
+    let listDepth = 0;
+
+    for (let i = 0; i < tokens.length; i++) {
+      const t = tokens[i];
+      if (t.type === "html_block" && /<ELSSteps[\s/>]/.test(t.content) && !/<\/ELSSteps>/.test(t.content)) {
+        inSteps++;
+        continue;
+      }
+      if (t.type === "html_block" && /<\/ELSSteps>/.test(t.content)) {
+        inSteps = Math.max(0, inSteps - 1);
+        continue;
+      }
+      if (!inSteps) continue;
+
+      if (t.type === "ordered_list_open") listDepth++;
+      else if (t.type === "ordered_list_close") listDepth--;
+
+      if (t.type === "list_item_open" && listDepth === 1) {
+        const base = slugify(clean(firstInlineText(tokens, i))) || "step";
+        let id = base;
+        let n = 0;
+        while (used.has(id)) id = `${base}-${++n}`;
+        used.add(id);
+        t.attrSet("id", id);
+      }
+    }
+  });
+}
+
+// ---- point 2: build HowTo JSON-LD from the markdown source ----
+function howToScripts(page: any): any[] {
+  const src: string = page?.content || "";
+  if (!src.includes("<ELSSteps")) return [];
+
+  const pageTitle = clean(page?.title || "");
+  const used = new Set<string>();
+  const scripts: any[] = [];
+
+  const blockRe = /<ELSSteps[^>]*>([\s\S]*?)<\/ELSSteps>/g;
+  let block: RegExpExecArray | null;
+  while ((block = blockRe.exec(src))) {
+    const steps: { id: string; name: string }[] = [];
+    // top-level numbered items only (no leading whitespace -> not nested)
+    const itemRe = /^(\d+)\.\s+(.+)$/gm;
+    let item: RegExpExecArray | null;
+    while ((item = itemRe.exec(block[1]))) {
+      const name = clean(item[2]);
+      const base = slugify(name) || "step";
+      let id = base;
+      let n = 0;
+      while (used.has(id)) id = `${base}-${++n}`;
+      used.add(id);
+      steps.push({ id, name });
+    }
+    if (!steps.length) continue;
+
+    const howTo = {
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      name: pageTitle || steps[0].name,
+      step: steps.map((s, n) => ({
+        "@type": "HowToStep",
+        position: n + 1,
+        name: s.name,
+        text: s.name,
+        url: `#${s.id}`,
+      })),
+    };
+    scripts.push(["script", { type: "application/ld+json" }, JSON.stringify(howTo)]);
+  }
+  return scripts;
+}
+
+export const elsStructuredDataPlugin = {
+  name: "els-structured-data",
+  extendsMarkdown: assignStepIds,
+  extendsPage: (page: any) => {
+    const scripts = howToScripts(page);
+    if (!scripts.length) return;
+    page.frontmatter.head = page.frontmatter.head || [];
+    page.frontmatter.head.push(...scripts);
+  },
+};

--- a/docs/.vuepress/utils/slugify.ts
+++ b/docs/.vuepress/utils/slugify.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared slug helper for anchor ids.
+ *
+ * Mirrors the rule used by VuePress markdown anchors in `config.ts`
+ * (strip ® / ™, lowercase, spaces -> "-") so component-generated anchors
+ * (steps, prerequisites) behave exactly like heading anchors. Additionally
+ * strips characters that aren't url/id-safe and collapses repeated hyphens.
+ */
+export function slugify(str: string): string {
+  return str
+    .replace(/®/g, '')
+    .replace(/™/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '') // drop non url-safe chars
+    .replace(/\s+/g, '-')         // spaces -> hyphens
+    .replace(/-+/g, '-')          // collapse repeats
+    .replace(/^-+|-+$/g, '');     // trim leading/trailing hyphens
+}
+
+/**
+ * Returns `base` if unused, otherwise appends -1, -2, ... until unique.
+ * Records the chosen id in `used` (mutates the set). Same dedupe behavior
+ * as markdown-it-anchor so step/prereq ids never collide with each other
+ * or with heading anchors already present on the page.
+ */
+export function uniqueId(base: string, used: Set<string>): string {
+  const safeBase = base || 'section';
+  let id = safeBase;
+  let i = 0;
+  while (used.has(id)) {
+    i += 1;
+    id = `${safeBase}-${i}`;
+  }
+  used.add(id);
+  return id;
+}
+
+/**
+ * Seeds a "used ids" set from every element already carrying an id within
+ * the given root (defaults to the whole document). Lets runtime-generated
+ * anchors avoid colliding with VuePress heading anchors and other blocks.
+ */
+export function collectUsedIds(root: ParentNode = document): Set<string> {
+  const used = new Set<string>();
+  root.querySelectorAll('[id]').forEach((el) => {
+    const id = el.getAttribute('id');
+    if (id) used.add(id);
+  });
+  return used;
+}


### PR DESCRIPTION
## What & why

`<ELSPrerequisites>` and `<ELSSteps>` are Vue component templates, so VuePress's
markdown anchor system (which only slugs `h2`–`h5` headings) never gave them ids —
there was nothing to deep-link to. This PR makes both **prerequisite sections and
individual steps deep-linkable**, and makes those anchors **machine-addressable in
the static HTML** (not only in the browser DOM), with schema.org structured data
for AI/agent consumption.

No markdown content needs to change — all existing pages get this automatically.

## Changes

### 1. Deep-link anchors (human UX)
- Each step gets a stable id slugified from its title (e.g. `#download-the-install-script`),
  deduped page-wide so multiple steps and multiple `<ELSSteps>` blocks never collide.
- Each Prerequisites section gets a `#prerequisites` section anchor.
- A `#` link (styled like the site's `h2` header-anchors) reveals on hover to the left
  of the wording; clicking it — **or the step's number badge** — updates the URL and
  scrolls below the fixed navbar.
- The step number badge changes color on hover.
- Step body content and the prerequisites list are indented to line up with the
  title/heading wording; anchors are vertically aligned with the text.

### 2. Build-time ids (machine-addressable)
- New `els-structured-data` plugin (`extendsMarkdown`) assigns `<li id="…">` to each
  top-level step at parse time, so the anchor is present in the **SSR HTML**, not only
  after the client script runs.
- `<ELSPrerequisites>` renders its section id server-side via a bound `:id`
  (overridable with `<ELSPrerequisites id="…">` when a page has more than one block).
- The components' `onMounted` now **reads** the build-time id and only attaches the
  visual `#` / clickable number (slugify kept as a runtime fallback).

### 3. schema.org HowTo (AI-readable)
- The same plugin (`extendsPage`) emits a `HowTo` / `HowToStep` JSON-LD `<script>` into
  the page `<head>`, with `url`s that match the step ids. (JSON-LD goes in `<head>`;
  injecting `<script>` into the page body breaks VuePress's SFC compilation.)

### Slug rule
- Shared `utils/slugify.ts` strips punctuation/signs (`, . ? ! '` …) from anchor urls.
  Markdown heading anchors (`config.ts`) now use it too, so the no-signs rule applies
  site-wide and build-time/runtime ids match.