### PR TITLE
fix(security): remove orphaned HubSpot loader from docs head

### DIFF
--- a/docs/.vuepress/headFunctions.ts
+++ b/docs/.vuepress/headFunctions.ts
@@ -4,16 +4,6 @@ export default [
   [
     "script",
     {
-      type: "text/javascript",
-      id: "hs-script-loader",
-      async: true,
-      defer: true,
-      src: "//js.hs-scripts.com/5408110.js",
-    },
-  ],
-  [
-    "script",
-    {
       type: "application/ld+json",
       id: "tc-org-schema",
     },


### PR DESCRIPTION
Removes the HubSpot tracking loader (//js.hs-scripts.com/5408110.js) injected site-wide via headFunctions.ts. The script is an old, orphaned tracker: it is not part of any GTM container and collects no data for docs.tuxcare.com (confirmed by marketing). It was the sole resource flagged by SecurityScorecard's unsafe_sri_v2 finding (GSR-9996, Finding 4); SRI cannot be applied to a versionless third-party loader, so removal is the correct remediation. No code depends on it.

Refs: GSR-9996, ELSDOC-309
