### PR TITLE
ELSDOC-317: document net-new ELS library releases (2026-06-23→06-29)

### DIFF
--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -156,7 +156,7 @@ const techData = [
       },
       {
         name: "Apache POI",
-        versions: "4.1.2",
+        versions: "3.10-FINAL | 4.1.2",
         link: "./java-libraries/",
       },
       {
@@ -668,7 +668,7 @@ const techData = [
       },
       {
         name: "axios",
-        versions: "0.15.3 | 0.18.1 | 0.27.2 | 0.33.0",
+        versions: "0.15.3 | 0.18.1 | 0.19.2 | 0.27.2 | 0.33.0",
         link: "./javascript-libraries/",
       },
       {
@@ -677,13 +677,28 @@ const techData = [
         link: "./javascript-libraries/",
       },
       {
+        name: "babel-helpers",
+        versions: "7.15.4 | 7.24.0 | 7.24.1 | 7.25.6 | 7.26.0",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "babel-plugin-transform-modules-systemjs",
+        versions: "7.15.4 | 7.23.9 | 7.24.1 | 7.25.0",
+        link: "./javascript-libraries/",
+      },
+      {
         name: "babel-runtime",
-        versions: "7.11.2 | 7.12.5 | 7.12.18 | 7.14.8 | 7.16.7 | 7.18.9 | 7.22.6 | 7.24.1",
+        versions: "7.11.2 | 7.12.5 | 7.12.18 | 7.14.8 | 7.15.4 | 7.16.7 | 7.18.9 | 7.21.0 | 7.22.6 | 7.22.15 | 7.23.1 | 7.23.2 | 7.23.9 | 7.24.0 | 7.24.1 | 7.24.4 | 7.24.7 | 7.25.7 | 7.26.0",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "babel-runtime-corejs3",
+        versions: "7.15.3",
         link: "./javascript-libraries/",
       },
       {
         name: "babel-traverse",
-        versions: "6.26.0",
+        versions: "6.26.0 | 7.15.4",
         link: "./javascript-libraries/",
       },
       {
@@ -697,19 +712,29 @@ const techData = [
         link: "./javascript-libraries/",
       },
       {
+        name: "bn.js",
+        versions: "4.11.8 | 4.12.0",
+        link: "./javascript-libraries/",
+      },
+      {
         name: "body-parser",
-        versions: "1.8.4 | 1.13.3 | 1.14.2",
+        versions: "1.8.4 | 1.13.3 | 1.14.2 | 1.19.0 | 1.20.1 | 1.20.2",
         link: "./javascript-libraries/",
       },
       {
         name: "Bootstrap",
-        versions: "3.2.0 | 3.3.6 | 3.4.1 | 4.1.1 | 4.6.2",
+        versions: "3.2.0 | 3.3.6 | 3.3.7 | 3.4.1 | 4.1.1 | 4.1.3 | 4.6.2",
         link: "./bootstrap/",
       },
       {
         name: "bootstrap-sass",
         versions: "3.4.0",
         link: "./bootstrap-sass/",
+      },
+      {
+        name: "bower",
+        versions: "1.8.4",
+        link: "./javascript-libraries/",
       },
       {
         name: "brace-expansion",
@@ -722,6 +747,11 @@ const techData = [
         link: "./javascript-libraries/",
       },
       {
+        name: "browserify-sign",
+        versions: "4.0.4 | 4.2.1",
+        link: "./javascript-libraries/",
+      },
+      {
         name: "browserslist",
         versions: "4.10.0 | 4.13.0 | 4.27.0",
         link: "./javascript-libraries/",
@@ -729,6 +759,16 @@ const techData = [
       {
         name: "bson",
         versions: "0.5.7 | 1.0.9",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "ckeditor",
+        versions: "4.5.11",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "ckeditor4",
+        versions: "4.17.1",
         link: "./javascript-libraries/",
       },
       {
@@ -908,7 +948,7 @@ const techData = [
       },
       {
         name: "follow-redirects",
-        versions: "0.0.3 | 1.15.11",
+        versions: "0.0.3 | 1.5.10 | 1.15.2 | 1.15.3 | 1.15.5 | 1.15.6 | 1.15.9 | 1.15.11",
         link: "./javascript-libraries/",
       },
       {
@@ -958,7 +998,7 @@ const techData = [
       },
       {
         name: "handlebars",
-        versions: "1.0.12 | 1.3.0 | 2.0.0 | 3.0.3",
+        versions: "1.0.12 | 1.3.0 | 2.0.0 | 3.0.3 | 4.7.7 | 4.7.8",
         link: "./javascript-libraries/",
       },
       {
@@ -1589,7 +1629,7 @@ const techData = [
       },
       {
         name: "cryptography",
-        versions: "3.4.8 | 41.0.7 | 42.0.0 | 42.0.8 | 43.0.1 | 43.0.3 | 44.0.3 | 45.0.7",
+        versions: "3.4.8 | 41.0.7 | 42.0.0 | 42.0.8 | 43.0.1 | 43.0.3 | 44.0.3 | 45.0.7 | 46.0.7",
         link: "./python-libraries/",
       },
       {
@@ -1639,7 +1679,7 @@ const techData = [
       },
       {
         name: "gunicorn",
-        versions: "20.0.4 | 20.1.0 | 21.2.0 | 22.0.0",
+        versions: "20.0.4 | 20.1.0 | 21.2.0 | 22.0.0 | 23.0.0",
         link: "./python-libraries/",
       },
       {

--- a/docs/els-for-libraries/bootstrap/README.md
+++ b/docs/els-for-libraries/bootstrap/README.md
@@ -4,7 +4,7 @@ Endless Lifecycle Support (ELS) for Bootstrap from TuxCare provides security fix
 
 ## Supported Bootstrap Versions
 
-* Bootstrap 3.2.0, 3.3.6, 3.4.1, 4.1.1, 4.6.2
+* Bootstrap 3.2.0, 3.3.6, 3.3.7, 3.4.1, 4.1.1, 4.1.3, 4.6.2
 
 ## Installation
 

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -15,7 +15,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Apache Commons IO** 2.4, 2.5, 2.6, 2.7, 2.11.0
 * **Apache FOP** 1.0
 * **Apache HttpComponents Client** 4.5.2
-* **Apache POI** 4.1.2
+* **Apache POI** 3.10-FINAL, 4.1.2
 * **Apache Santuario XML Security For Java** 2.0.10, 2.3.1
 * **Apache Thrift** 0.9.1, 0.9.3
 * **Apache Tika** 2.9.4

--- a/docs/els-for-libraries/javascript-libraries/README.md
+++ b/docs/els-for-libraries/javascript-libraries/README.md
@@ -13,19 +13,27 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **ansi-html** 0.0.7
 * **ansi-regex** 3.0.0
 * **async** 2.6.1, 2.6.3
-* **axios** 0.15.3, 0.18.1, 0.27.2, 0.33.0
+* **axios** 0.15.3, 0.18.1, 0.19.2, 0.27.2, 0.33.0
 * **azure-identity** 4.0.1
-* **babel-runtime** 7.11.2, 7.12.5, 7.12.18, 7.14.8, 7.16.7, 7.18.9, 7.22.6, 7.24.1
-* **babel-traverse** 6.26.0
+* **babel-helpers** 7.15.4, 7.24.0, 7.24.1, 7.25.6, 7.26.0
+* **babel-plugin-transform-modules-systemjs** 7.15.4, 7.23.9, 7.24.1, 7.25.0
+* **babel-runtime** 7.11.2, 7.12.5, 7.12.18, 7.14.8, 7.15.4, 7.16.7, 7.18.9, 7.21.0, 7.22.6, 7.22.15, 7.23.1, 7.23.2, 7.23.9, 7.24.0, 7.24.1, 7.24.4, 7.24.7, 7.25.7, 7.26.0
+* **babel-runtime-corejs3** 7.15.3
+* **babel-traverse** 6.26.0, 7.15.4
 * **base64url** 0.0.6
 * **basic-ftp** 5.0.5, 5.3.1
-* **body-parser** 1.8.4, 1.13.3, 1.14.2
+* **bn.js** 4.11.8, 4.12.0
+* **body-parser** 1.8.4, 1.13.3, 1.14.2, 1.19.0, 1.20.1, 1.20.2
+* **bower** 1.8.4
 * **brace-expansion** 1.1.11, 2.0.1
 * **braces** 0.1.5, 1.8.5, 2.3.1, 2.3.2, 3.0.2, 3.0.3
+* **browserify-sign** 4.0.4, 4.2.1
 * **browserslist** 4.10.0, 4.13.0, 4.27.0
 * **bson** 0.5.7, 1.0.9
 * **chownr** 0.0.2, 1.0.1
 * **cipher-base** 1.0.4
+* **ckeditor** 4.5.11
+* **ckeditor4** 4.17.1
 * **clean-css** 2.2.23, 3.4.28
 * **concat-stream** 1.4.8, 1.4.10, 1.5.0
 * **connect** 1.9.2, 2.6.0, 2.7.5
@@ -56,7 +64,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **fast-xml-parser** 3.14.0, 3.17.5, 3.19.0, 4.2.7, 4.4.0, 4.5.3, 4.5.6
 * **file-type** 17.1.6
 * **flatted** 3.2.9, 3.3.3
-* **follow-redirects** 0.0.3, 1.15.11
+* **follow-redirects** 0.0.3, 1.5.10, 1.15.2, 1.15.3, 1.15.5, 1.15.6, 1.15.9, 1.15.11
 * **form-data** 0.0.8, 0.1.4, 0.2.0, 1.0.0-rc3, 1.0.1, 2.0.0, 2.1.4, 2.3.3, 4.0.0, 4.0.1
 * **formidable** 2.1.2, 2.1.5
 * **forwarded** 0.1.0
@@ -66,7 +74,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **glob** 10.2.6, 10.4.5
 * **got** 2.9.2, 8.3.2, 9.6.0
 * **growl** 1.7.0
-* **handlebars** 1.0.12, 1.3.0, 2.0.0, 3.0.3
+* **handlebars** 1.0.12, 1.3.0, 2.0.0, 3.0.3, 4.7.7, 4.7.8
 * **hapi-hoek** 6.2.4
 * **hawk** 0.13.1, 1.0.0, 1.1.1, 2.3.1, 3.1.0
 * **highlight.js** 9.18.5

--- a/docs/els-for-libraries/python-libraries/README.md
+++ b/docs/els-for-libraries/python-libraries/README.md
@@ -7,7 +7,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **aiohttp** 3.8.1, 3.8.4, 3.8.5, 3.8.6
 * **apache-airflow-providers-http** 4.13.3
 * **certifi** 2021.10.8, 2022.12.7, 2023.7.22
-* **cryptography** 3.4.8, 41.0.7, 42.0.0, 42.0.8, 43.0.1, 43.0.3, 44.0.3, 45.0.7
+* **cryptography** 3.4.8, 41.0.7, 42.0.0, 42.0.8, 43.0.1, 43.0.3, 44.0.3, 45.0.7, 46.0.7
 * **deepdiff** 6.2.3
 * **dnspython** 2.3.0
 * **dulwich** 0.25.2
@@ -15,7 +15,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **flask-cors** 4.0.2
 * **future** 1.0.0
 * **GitPython** 3.1.31
-* **gunicorn** 20.0.4, 20.1.0, 21.2.0, 22.0.0
+* **gunicorn** 20.0.4, 20.1.0, 21.2.0, 22.0.0, 23.0.0
 * **h11** 0.9.0
 * **httpx** 0.22.0
 * **idna** 2.1, 2.8, 2.10, 3.6


### PR DESCRIPTION
Add net-new package/version doc gaps to the ELS for Libraries listing pages and the ELSTechnology.vue version matrix. Follow-up to ELSDOC-312.

Python (els_python):
- cryptography 46.0.7, gunicorn 23.0.0 (new upstream)

JavaScript (els_js):
- New packages: babel-helpers, babel-plugin-transform-modules-systemjs, babel-runtime-corejs3, bn.js, bower, browserify-sign, ckeditor, ckeditor4
- New upstream on existing entries: axios 0.19.2, body-parser 1.19.0/1.20.1/1.20.2, follow-redirects 1.5.10/1.15.2/1.15.3/1.15.5/ 1.15.6/1.15.9, handlebars 4.7.7/4.7.8, babel-runtime (7.15.4/7.21.0/ 7.22.15/7.23.1/7.23.2/7.23.9/7.24.0/7.24.4/7.24.7/7.25.7/7.26.0), babel-traverse 7.15.4, bootstrap 3.3.7/4.1.3

Java (els_java):
- Apache POI 3.10-FINAL (new upstream)