### PR TITLE
STAR-71: Close search drawer when a result is clicked

### DIFF
--- a/docs/.vuepress/theme/drawer/Drawer.vue
+++ b/docs/.vuepress/theme/drawer/Drawer.vue
@@ -17,7 +17,7 @@
             <div class="drawer-main__breadcrumb">
               <!-- Optional breadcrumb can stay here -->
             </div>
-            <DrawerSearchResult :modelValue="modelValue" :data="drawerArticleResult"/>
+            <DrawerSearchResult :modelValue="modelValue" :data="drawerArticleResult" @closeDrawer="onCloseDrawer"/>
           </div>
         </div>
         <Footer v-if="isOpenDrawer && isMobileWidth" class="drawer-footer__mobile"/>

--- a/docs/.vuepress/theme/drawer/DrawerSearchResult.vue
+++ b/docs/.vuepress/theme/drawer/DrawerSearchResult.vue
@@ -61,7 +61,14 @@ const props = defineProps({
 const { MAX_VISIBLE_RESULT } = inject("themeConfig");
 const isShowAllResult = ref(false);
 
+const emit = defineEmits(["closeDrawer"]);
+
 const gotTo = (url) => {
+  // Always close the search drawer on click. When the target resolves to the
+  // page we are already on (same pathname, only the #hash differs) the browser
+  // does NOT reload, so the drawer would otherwise stay open over the page and
+  // the result would look unclickable (STAR-71).
+  emit("closeDrawer");
   const parsedCurrentUrl = new URL(window.location.href);
   if (parsedCurrentUrl.pathname + parsedCurrentUrl.hash === url) {
     window.location.reload();


### PR DESCRIPTION
## Problem

[STAR-71] **Search results not closing under some circumstances.** Reported by devs; confirmed still reproducible on production (`docs.tuxcare.com`) via Playwright.

The search drawer was only torn down as a *side effect of a full page reload*. When a clicked result resolves to the page the user is already on — **same pathname, only the `#hash` differs** — `window.location.href` does **not** reload the page. The drawer therefore stayed open as an overlay while the content silently scrolled behind it, so the result looked **unclickable**.

This is the same root cause behind the comment-thread report that "when docs is initially open with a `#hash-anchor` in the URL, some links become not clickable" — that's just one instance of *the result points to the current page*.

### Reproduced on production (before fix)
1. Open `https://docs.tuxcare.com/live-patching-services/` (with or without a `#hash`)
2. Search, then click a result pointing to the **same page** (e.g. `…/live-patching-services/#command-line-tools`)
3. URL + scroll position change, but `.drawer.is-open` **stays open** → looks like a dead link.

## Fix

`DrawerSearchResult` now emits `closeDrawer` on click; `Drawer` forwards it through the existing event chain to `HeaderLayoutSearch.closeDrawer`. The drawer now closes on **every** navigation — full reload *or* hash-only.

- `DrawerSearchResult.vue` — `defineEmits(["closeDrawer"])` + `emit("closeDrawer")` at the top of `gotTo()`.
- `Drawer.vue` — bind `@closeDrawer="onCloseDrawer"` on `<DrawerSearchResult>` (reuses the existing emit chain).

## Verification (Playwright, local build)

Exercised the previously-broken **same-page / hash-only / no-reload** path:

| | Before | After |
|---|---|---|
| Drawer after click | stays `is-open` | **closes** |
| Page reload | none | none (hash-only) |
| Scroll to anchor | hidden behind drawer | visible |
| body scroll-lock | stuck on | released |

Confirmed no full reload occurred on the tested path (an in-page marker survived the click), proving the drawer now closes via the event chain rather than as a reload side effect.

## Notes / out of scope
- Issue #1 from the thread (results not openable in a new tab) is already fixed — results now render a real `<a href>`; verified on production.
- Issue #2 (Back button returns to the initial page rather than the previous search results) is a separate, larger SPA-history change and is intentionally **not** addressed here, per Bogdan's comment suggesting a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)