### PR TITLE
Fix search drawer close-animation flashing on initial page load

### DIFF
--- a/docs/.vuepress/theme/drawer/Drawer.vue
+++ b/docs/.vuepress/theme/drawer/Drawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="drawer" :class="{'is-open': isOpenDrawer}" tabindex="0">
+    <div class="drawer" :class="{'is-open': isOpenDrawer, 'drawer--animated': animationsReady}" tabindex="0">
       <div class="drawer-header">
         <div class="drawer-header__wrapper">
           <h2 class="drawer-header__paragraph">How can we help you?</h2>
@@ -30,7 +30,7 @@
 <script setup>
 import { withBase } from "@vuepress/client";
 import Footer from "../footer/Footer.vue";
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import DrawerSearchResult from "./DrawerSearchResult.vue";
 
 const props = defineProps({
@@ -66,6 +66,16 @@ const onCloseDrawer = () => {
   emit('closeDrawer');
 }
 
+// The drawer starts hidden (translateY(-100%)). Enabling the slide transition
+// only after the first paint prevents the close animation from flashing on
+// initial page load — it then fires only on genuine open/close toggles.
+const animationsReady = ref(false);
+onMounted(() => {
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    animationsReady.value = true;
+  }));
+});
+
 watch(() => props.isOpenDrawer, () => {
   document.body.classList.toggle('disable-scroll', props.isOpenDrawer);
 });
@@ -89,7 +99,12 @@ watch(() => props.isOpenDrawer, () => {
   background: $drawerHeaderBgColor
   opacity: 0;
   transform: translateY(-100%);
-  transition: 0.4s ease;
+
+  // Transition is intentionally NOT set here so the initial hidden state is
+  // applied instantly (no flash on first load). It is enabled via
+  // .drawer--animated once the component has mounted.
+  &.drawer--animated
+    transition: 0.4s ease
 
   &-header
     padding 1.25rem $layout-horizontal-padding


### PR DESCRIPTION
## Problem

On first page load the search drawer's **close animation can flash**. The `.drawer` element starts hidden (`transform: translateY(-100%); opacity: 0`) but carried an **unconditional `transition: 0.4s ease`**. When the hidden state is applied during initial render/hydration, the transition can run, briefly playing the slide/close animation the user never triggered.

## Fix

Gate the transition so it only exists **after the component has mounted**:

- `Drawer.vue` template — add a `drawer--animated` class bound to a new `animationsReady` ref.
- Script — `animationsReady` flips to `true` in `onMounted` after a double `requestAnimationFrame` (i.e. after the first paint of the hidden state).
- Style — the `transition: 0.4s ease` moves off `.drawer` and onto `.drawer.drawer--animated`.

Result: on initial load the hidden state is applied **instantly with no transition** (no flash). Genuine open/close toggles still animate exactly as before.

## Verification (Playwright, local build)

- On fresh load the drawer settles hidden; once mounted, `.drawer--animated` is present and `transition-duration` is `0.4s`.
- Opening search runs the open transition (opacity + transform); closing runs the close transition — both still animate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)