### PR TITLE
docs(els-for-os): GPG verification & integrity violation events (COMPLIANCE-249)

### DIFF
--- a/docs/els-for-os/machine-readable-security-data/README.md
+++ b/docs/els-for-os/machine-readable-security-data/README.md
@@ -140,3 +140,337 @@ TuxCare publishes the following CSAF files at [security.tuxcare.com](https://sec
 
 TuxCare provides RSS feeds for tracking new ELS releases. RSS links for each OS are listed in the [Security data feeds](#security-data-feeds) table above.
 
+## Package Signature Verification (GPG)
+
+Every package TuxCare builds for ELS for OS is cryptographically signed, so the
+package manager can confirm — before anything is installed or updated — that the
+package was produced by TuxCare and has not been altered in transit. Unlike a
+manual, per-file check, this verification is **built into the native package
+manager (`yum`/`dnf`, `apt`, `apk`) and enabled by default**: the ELS release
+package you install during setup imports TuxCare's signing key and turns
+signature checking on, so every subsequent transaction is verified automatically.
+
+A successful verification proves two things about a package:
+
+* **Authenticity** — it was signed by TuxCare's private key.
+* **Integrity** — its bytes match exactly what was signed; no tampering or corruption occurred.
+
+A failed verification is an **integrity violation**: the package manager refuses
+to install the package. Do not work around a failed check — for example by
+disabling GPG checking or downloading over an insecure channel — investigate the
+source instead.
+
+### How Packages and Repository Metadata Are Signed
+
+<TableTabs label="Choose distribution: ">
+
+<template #RPM>
+
+The ELS release package (`els-define` / `els-os-release`) installs TuxCare's
+public key at `/etc/pki/rpm-gpg/RPM-GPG-KEY-TuxCare` and configures the
+repositories under `/etc/yum.repos.d/` with `gpgcheck=1`. Every RPM carries a
+GPG signature in its header, which `yum`/`dnf` verifies against that key on every
+install and update.
+
+TuxCare also publishes a detached signature of the repository metadata index
+(`repodata/repomd.xml.asc`). Verifying it additionally protects the metadata
+itself against tampering; enable it with `repo_gpgcheck=1`.
+
+:::warning
+By default the ELS `.repo` files enable `gpgcheck=1` (package signatures) but do
+**not** enable `repo_gpgcheck=1` (repository metadata signature). To have the
+package manager also enforce the metadata signature, add `repo_gpgcheck=1` to the
+repository section:
+
+```text
+[centos7-els]
+...
+gpgcheck=1
+repo_gpgcheck=1
+```
+:::
+
+</template>
+
+<template #DEB>
+
+The `els-os-release` package installs TuxCare's public key at
+`/etc/apt/trusted.gpg.d/tuxcare-keyring.gpg` and adds the repository under
+`/etc/apt/sources.list.d/`. `apt` verifies the OpenPGP signature over the
+repository release index (`InRelease` / `Release.gpg`) on every `apt-get update`,
+and then verifies each downloaded `.deb` against the checksums recorded in that
+signed index. In the Debian/apt model the package guarantee is anchored in this
+signed metadata index rather than in a separate per-`.deb` signature.
+
+</template>
+
+<template #APK>
+
+The `els-alpine-release` package installs TuxCare's public key in
+`/etc/apk/keys/` and adds the repository under `/etc/apk/repositories.d/`. Every
+Alpine package and the repository index (`APKINDEX.tar.gz`) are signed; `apk`
+verifies both against the key on every `apk add` and `apk upgrade`.
+
+</template>
+
+</TableTabs>
+
+### Confirm the TuxCare Signing Key Is Installed
+
+<TableTabs label="Choose distribution: ">
+
+<template #RPM>
+
+```text
+rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep -i tuxcare
+```
+
+</template>
+
+<template #DEB>
+
+```text
+gpg --show-keys /etc/apt/trusted.gpg.d/tuxcare-keyring.gpg
+```
+
+</template>
+
+<template #APK>
+
+```text
+ls /etc/apk/keys/
+```
+
+</template>
+
+</TableTabs>
+
+### Verify a Package
+
+Because verification is automatic, the primary check is simply that a normal
+install or update succeeds. You can also verify a downloaded package explicitly.
+
+<TableTabs label="Choose distribution: ">
+
+<template #RPM>
+
+A normal transaction verifies signatures automatically:
+
+```text
+yum install <package>
+```
+
+To verify an already-downloaded `.rpm` file explicitly:
+
+```text
+rpm -K <package>.rpm
+```
+
+`<package>.rpm: digests signatures OK` confirms authenticity and integrity.
+`NOT OK`, or a missing public key, is an integrity violation — stop and
+re-obtain the package from TuxCare over a trusted channel.
+
+</template>
+
+<template #DEB>
+
+`apt` verifies the signed repository index on update and the package checksums on
+install:
+
+```text
+apt-get update
+apt-get install <package>
+```
+
+A `GPG error` on `apt-get update`, or a `Hash Sum mismatch` on install, is an
+integrity violation — the operation stops.
+
+</template>
+
+<template #APK>
+
+`apk` verifies the package and index signatures automatically:
+
+```text
+apk add <package>
+```
+
+An `UNTRUSTED signature` or `BAD signature` message is an integrity violation —
+the operation stops.
+
+</template>
+
+</TableTabs>
+
+## Integrity Violation Events
+
+An **integrity violation** is any event where a package obtained from TuxCare — or
+the channel it was retrieved over — fails a verification check, indicating the
+package may not be authentic or may have been altered in transit. The package
+manager already **blocks** the operation (the install or update stops), but by
+default the only trace is the command's exit code and whatever scrolled past in
+the terminal. To align with the EU Cyber Resilience Act (CRA), these events
+should be treated as security-relevant and retained in a dedicated log so a
+system administrator can review them regardless of when or how the update was
+triggered.
+
+### What Counts as an Integrity Violation
+
+ELS for OS is delivered through the native OS package repositories — `yum`/`dnf`
+for RPM-based systems (CentOS, Oracle Linux, RHEL, AlmaLinux, and similar),
+`apt` for Debian and Ubuntu, and `apk` for Alpine — served exclusively over
+HTTPS, with GPG-signed packages and repository metadata. The following
+verification failures are integrity violations. Select your distribution:
+
+<TableTabs label="Choose distribution: ">
+
+<template #RPM>
+
+| Event | What it means | How it surfaces |
+|---|---|---|
+| **GPG signature failure** | The package's header signature does not match, or the package was not signed by TuxCare's key. Enforced by default (`gpgcheck=1`). | `yum`/`dnf` abort with `GPG check FAILED` / `Package <name> is not signed`; `rpm -K` reports `NOT OK`. |
+| **Metadata signature mismatch** | The detached signature over the repository metadata index (`repomd.xml.asc`) does not verify. TuxCare signs the metadata; verification is off unless `repo_gpgcheck=1` is set (see [Package Signature Verification](#package-signature-verification-gpg)). | `dnf` aborts with `repomd.xml GPG signature verification error` / `Error: Failed to download metadata for repo '<id>': repomd.xml signature could not be verified`. |
+| **Checksum / integrity-hash mismatch** | A downloaded package does not match the checksum recorded in the repository metadata — the bytes changed in transit or the package was substituted. Always enforced. | `yum` fails with `[Errno -1] Package does not match intended download`; `dnf` with `checksum ... does not match`. |
+| **HTTPS / TLS certificate error** | The TLS certificate presented by the repository host cannot be validated, so the transport itself cannot be trusted. Enforced by default (`sslverify=1`). | `Curl error (60): SSL certificate problem` / `Peer's certificate issuer has been marked as not trusted`. |
+
+</template>
+
+<template #DEB>
+
+| Event | What it means | How it surfaces |
+|---|---|---|
+| **GPG signature failure** | The repository release index (`InRelease` / `Release.gpg`) is not signed by a trusted key, or the signing key is missing. Enforced by default. | `apt-get update` reports `NO_PUBKEY <id>` / `The following signatures were invalid` / `is not signed`. |
+| **Metadata signature mismatch** | The signed release index does not match its contents (a tampered metadata index). apt verifies this as part of the same OpenPGP check over `InRelease`. | `apt-get update` reports a `GPG error` / `Hash Sum mismatch` on `InRelease`. |
+| **Checksum / hash mismatch** | A downloaded `.deb` does not match the hash recorded in the signed index. Enforced by default. | `apt-get install` fails with `Hash Sum mismatch` / `Size mismatch`. |
+| **HTTPS / TLS certificate error** | The TLS certificate presented by the repository host cannot be validated. | `apt-get update` fails with `server certificate verification failed` / `gnutls_handshake() failed`. |
+
+:::tip
+For apt, package trust is anchored in the GPG-signed release index rather than in
+individual `.deb` signatures, so "GPG signature failure" and "metadata signature
+mismatch" are two facets of the same `InRelease` check. Both are enforced by
+default.
+:::
+
+</template>
+
+<template #APK>
+
+| Event | What it means | How it surfaces |
+|---|---|---|
+| **GPG / package signature failure** | The package is signed by a key that is not in `/etc/apk/keys/`, or the signature does not match. Enforced by default. | `apk add` reports `UNTRUSTED signature` / `BAD signature`. |
+| **Metadata signature mismatch** | The signature over the repository index (`APKINDEX.tar.gz`) does not verify. Enforced by default. | `apk update` reports `UNTRUSTED` on the index / a verification error. |
+| **Checksum / integrity-hash mismatch** | A downloaded package does not match the hash recorded in the signed index. Enforced by default. | `apk` aborts with a `sha256` mismatch / integrity error. |
+| **HTTPS / TLS certificate error** | The TLS certificate presented by the repository host cannot be validated. | `apk` fails with `tls_handshake:` / `certificate verification failed`. |
+
+</template>
+
+</TableTabs>
+
+### Capturing Integrity Violations in a Dedicated Log
+
+Because these checks run inside the package manager, their outcome lives only in
+the command's exit code and console output. To retain violations for later
+review — as CRA expects — run the update or install inside a wrapper that writes
+the result to a dedicated log, separate from ordinary output. Running this from a
+scheduled job, a cron task, or a configuration-management run guarantees the
+event is captured no matter who triggered the update or whether anyone was
+watching the terminal.
+
+<TableTabs label="Choose distribution: ">
+
+<template #RPM>
+
+`yum`/`dnf` verify package signatures (`gpgcheck=1`), checksums, and TLS on every
+transaction; add `repo_gpgcheck=1` to the repository configuration to also
+enforce the metadata signature. A non-zero exit is written to a dedicated log
+file and to the system journal.
+
+```bash
+#!/usr/bin/env bash
+set -o pipefail
+LOG=/var/log/tuxcare-integrity.log
+
+if yum -y update; then
+  logger -t tuxcare-integrity -p authpriv.info "OK: yum update"
+else
+  rc=$?
+  msg="INTEGRITY VIOLATION: yum update (exit ${rc})"
+  echo "$(date -u +%FT%TZ) ${msg}" | tee -a "$LOG"
+  logger -t tuxcare-integrity -p authpriv.err "${msg}"
+  exit 1
+fi
+```
+
+(On dnf-based systems, use `dnf -y update` in place of `yum -y update`.)
+
+</template>
+
+<template #DEB>
+
+`apt` verifies the signed release index and package checksums, and enforces TLS,
+on every run. A non-zero exit from either step is written to a dedicated log file
+and to the system journal.
+
+```bash
+#!/usr/bin/env bash
+set -o pipefail
+LOG=/var/log/tuxcare-integrity.log
+
+if apt-get update && apt-get -y upgrade; then
+  logger -t tuxcare-integrity -p authpriv.info "OK: apt upgrade"
+else
+  rc=$?
+  msg="INTEGRITY VIOLATION: apt upgrade (exit ${rc})"
+  echo "$(date -u +%FT%TZ) ${msg}" | tee -a "$LOG"
+  logger -t tuxcare-integrity -p authpriv.err "${msg}"
+  exit 1
+fi
+```
+
+</template>
+
+<template #APK>
+
+`apk` verifies package and index signatures, checksums, and TLS on every run. A
+non-zero exit is written to a dedicated log file and to the system journal.
+
+```bash
+#!/bin/sh
+LOG=/var/log/tuxcare-integrity.log
+
+if apk update && apk upgrade; then
+  logger -t tuxcare-integrity -p authpriv.info "OK: apk upgrade"
+else
+  rc=$?
+  msg="INTEGRITY VIOLATION: apk upgrade (exit ${rc})"
+  echo "$(date -u +%FT%TZ) ${msg}" | tee -a "$LOG"
+  logger -t tuxcare-integrity -p authpriv.err "${msg}"
+  exit 1
+fi
+```
+
+</template>
+
+</TableTabs>
+
+`logger` hands the event to journald/rsyslog under the `tuxcare-integrity` tag.
+To route these events into their own file, add an rsyslog rule:
+
+```text
+# /etc/rsyslog.d/30-tuxcare-integrity.conf
+:programname, isequal, "tuxcare-integrity"   /var/log/tuxcare-integrity.log
+& stop
+```
+
+Reload rsyslog afterwards (`systemctl restart rsyslog`). To review the captured
+events through journald instead of a file:
+
+```text
+journalctl -t tuxcare-integrity
+```
+
+:::tip
+Forward `/var/log/tuxcare-integrity.log` (or the `tuxcare-integrity` journald
+tag) to your central log collector or SIEM so integrity violations are alerted on
+and retained under your standard log-retention policy.
+:::


### PR DESCRIPTION
Adds two sections to the ELS for OS `machine-readable-security-data` page for RPM/DEB/APK:

- **Package Signature Verification (GPG)** — how packages and repository metadata are signed, how to confirm the TuxCare key is installed, and how to verify a package.
- **Integrity Violation Events** — defines the four CRA event types (GPG signature failure, metadata signature mismatch, checksum error, HTTPS/TLS certificate error) per distribution with the real package-manager error strings, plus how to retain them in a dedicated log (logger + rsyslog/journald).

Grounded in the actual release-package configuration (`els-define` / `els-os-release` / `els-alpine-release`). Package signatures are enforced by default; RPM repository-metadata signature verification requires `repo_gpgcheck=1` client-side (called out explicitly).

Ref: COMPLIANCE-249