### PR TITLE
ELS Java docs: add missing upstream versions across libraries + Spring

### DIFF
--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -388,7 +388,7 @@ const techData = [
       {
         name: "Hibernate Commons Annotations",
         versions: "5.1.2.Final",
-        link: "./java-libraries/",
+        link: "./hibernate/",
       },
       {
         name: "Hibernate Search",
@@ -398,7 +398,7 @@ const techData = [
       {
         name: "Hibernate Validator",
         versions: "5.4.3.Final | 6.2.5.Final",
-        link: "./java-libraries/",
+        link: "./hibernate/",
       },
       {
         name: "HornetQ",
@@ -576,11 +576,6 @@ const techData = [
         link: "./java-libraries/",
       },
       {
-        name: "reload4j",
-        versions: "1.2.16",
-        link: "./java-libraries/",
-      },
-      {
         name: "Retrofit",
         versions: "2.9.0",
         link: "./java-libraries/",
@@ -723,11 +718,6 @@ const techData = [
       {
         name: "WildFly",
         versions: "27.0.1.Final",
-        link: "./java-libraries/",
-      },
-      {
-        name: "WildFly Core",
-        versions: "19.0.1.Final",
         link: "./java-libraries/",
       },
       {

--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -650,7 +650,7 @@ const techData = [
       },
       {
         name: "Spring® Security",
-        versions: "1.3 | 4.2 | 5.6 | 5.7 | 5.8 | 6.1 | 6.2 | 6.3 | 6.4",
+        versions: "4.2 | 5.6 | 5.7 | 5.8 | 6.1 | 6.2 | 6.3 | 6.4",
         link: "./spring/",
         detailsHash: "Security",
       },
@@ -707,7 +707,7 @@ const techData = [
       },
       {
         name: "Spring® Authorization Server",
-        versions: "1.1.4",
+        versions: "1.1.4 | 1.3.7",
         link: "./spring/",
       },
       {

--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -105,11 +105,6 @@ const techData = [
         link: "./java-libraries/",
       },
       {
-        name: "Apache Batik",
-        versions: "1.7",
-        link: "./java-libraries/",
-      },
-      {
         name: "Apache Commons BeanUtils",
         versions: "1.6 | 1.8.0 | 1.8.3 | 1.9.4 | 1.10.1",
         link: "./java-libraries/",
@@ -258,6 +253,11 @@ const techData = [
       {
         name: "Apache Xalan",
         versions: "2.7.1",
+        link: "./java-libraries/",
+      },
+      {
+        name: "Apache XML Graphics Batik",
+        versions: "1.7",
         link: "./java-libraries/",
       },
       {

--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -716,11 +716,6 @@ const techData = [
         link: "./java-libraries/",
       },
       {
-        name: "WildFly",
-        versions: "27.0.1.Final",
-        link: "./java-libraries/",
-      },
-      {
         name: "Woodstox",
         versions: "5.0.3 | 5.3.0",
         link: "./java-libraries/",

--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -85,8 +85,13 @@ const techData = [
     ecosystemIcon: "/images/java.webp",
     projects: [
       {
+        name: "Aircompressor",
+        versions: "0.27",
+        link: "./java-libraries/",
+      },
+      {
         name: "Apache ActiveMQ Artemis",
-        versions: "2.26.0",
+        versions: "2.26.0 | 2.33.0",
         link: "./java-libraries/",
       },
       {
@@ -100,8 +105,18 @@ const techData = [
         link: "./java-libraries/",
       },
       {
+        name: "Apache Batik",
+        versions: "1.7",
+        link: "./java-libraries/",
+      },
+      {
         name: "Apache Commons BeanUtils",
         versions: "1.6 | 1.8.0 | 1.8.3 | 1.9.4 | 1.10.1",
+        link: "./java-libraries/",
+      },
+      {
+        name: "Apache Commons Collections",
+        versions: "3.2 | 3.2.1",
         link: "./java-libraries/",
       },
       {
@@ -116,7 +131,7 @@ const techData = [
       },
       {
         name: "Apache Commons FileUpload",
-        versions: "1.2.1 | 1.2.2",
+        versions: "1.2.1 | 1.2.2 | 1.5",
         link: "./java-libraries/",
       },
       {
@@ -146,7 +161,7 @@ const techData = [
       },
       {
         name: "Apache CXF",
-        versions: "3.5.9 | 3.5.11",
+        versions: "3.4.5 | 3.5.9 | 3.5.11",
         link: "./apache-cxf/",
       },
       {
@@ -157,6 +172,11 @@ const techData = [
       {
         name: "Apache HttpComponents Client",
         versions: "4.5.2",
+        link: "./java-libraries/",
+      },
+      {
+        name: "Apache Ivy",
+        versions: "2.3.0",
         link: "./java-libraries/",
       },
       {
@@ -176,12 +196,12 @@ const techData = [
       },
       {
         name: "Apache Kafka®",
-        versions: "3.2.3 | 3.7.1",
+        versions: "2.8.2 | 3.2.3 | 3.7.1",
         link: "./apache-kafka/",
       },
       {
         name: "Apache Log4j",
-        versions: "1.2.16 | 1.2.17 | 2.17.1 | 2.22.1",
+        versions: "1.2.16 | 1.2.17 | 2.17.1 | 2.17.2 | 2.22.1",
         link: "./apache-log4j/",
       },
       {
@@ -196,7 +216,7 @@ const techData = [
       },
       {
         name: "Apache Maven",
-        versions: "3.8.1",
+        versions: "3.0.5 | 3.8.1",
         link: "./java-libraries/",
       },
       {
@@ -232,8 +252,13 @@ const techData = [
       },
       {
         name: "Apache Velocity Engine™",
-        versions: "1.7",
+        versions: "1.7 | 1.7.1",
         link: "./apache-velocity-engine/",
+      },
+      {
+        name: "Apache Xalan",
+        versions: "2.7.1",
+        link: "./java-libraries/",
       },
       {
         name: "Apache XML Graphics Commons",
@@ -242,7 +267,7 @@ const techData = [
       },
       {
         name: "Apache XMLBeans",
-        versions: "2.6.0",
+        versions: "2.3.0 | 2.6.0",
         link: "./java-libraries/",
       },
       {
@@ -306,8 +331,18 @@ const techData = [
         link: "./elasticsearch/",
       },
       {
+        name: "EWS Java API",
+        versions: "2.0",
+        link: "./java-libraries/",
+      },
+      {
         name: "excel-streaming-reader",
         versions: "5.0.2",
+        link: "./java-libraries/",
+      },
+      {
+        name: "GlassFish",
+        versions: "3.0.0",
         link: "./java-libraries/",
       },
       {
@@ -347,13 +382,23 @@ const techData = [
       },
       {
         name: "Hibernate",
-        versions: "4.3.11.Final | 5.4.3.Final | 5.4.30.Final | 5.4.31.Final | 5.4.32.Final | 5.4.33.Final | 5.5.6.Final | 5.5.9.Final | 5.6.15.Final | 6.2.5.Final",
+        versions: "4.3.11.Final | 5.1.2.Final | 5.4.3.Final | 5.4.30.Final | 5.4.31.Final | 5.4.32.Final | 5.4.33.Final | 5.5.6.Final | 5.5.9.Final | 5.6.15.Final | 6.2.5.Final",
         link: "./hibernate/",
+      },
+      {
+        name: "Hibernate Commons Annotations",
+        versions: "5.1.2.Final",
+        link: "./java-libraries/",
       },
       {
         name: "Hibernate Search",
         versions: "5.11.10.Final",
         link: "./hibernate/",
+      },
+      {
+        name: "Hibernate Validator",
+        versions: "5.4.3.Final | 6.2.5.Final",
+        link: "./java-libraries/",
       },
       {
         name: "HornetQ",
@@ -377,12 +422,12 @@ const techData = [
       },
       {
         name: "Jackson",
-        versions: "1.9.13 | 2.14.2",
+        versions: "1.9.13 | 2.12.1 | 2.14.1 | 2.14.2",
         link: "./jackson/",
       },
       {
         name: "JasperReports",
-        versions: "3.7.4",
+        versions: "3.7.4 | 6.2.2 | 6.21.5",
         link: "./java-libraries/",
       },
       {
@@ -412,7 +457,17 @@ const techData = [
       },
       {
         name: "JSON Smart v2",
-        versions: "2.4.8",
+        versions: "1.3.2 | 2.4.8",
+        link: "./java-libraries/",
+      },
+      {
+        name: "json-io",
+        versions: "2.9.4",
+        link: "./java-libraries/",
+      },
+      {
+        name: "jsoup",
+        versions: "1.7.2",
         link: "./java-libraries/",
       },
       {
@@ -446,13 +501,18 @@ const techData = [
         link: "./java-libraries/",
       },
       {
+        name: "MySQL Connector/J",
+        versions: "5.1.49",
+        link: "./java-libraries/",
+      },
+      {
         name: "NekoHTML",
         versions: "1.9.22",
         link: "./java-libraries/",
       },
       {
         name: "Netty",
-        versions: "4.1.115.Final | 4.1.48.Final | 4.1.49.Final | 4.1.52.Final | 4.1.58.Final | 4.1.60.Final | 4.1.63.Final | 4.1.73.Final | 4.1.75.Final | 4.1.82.Final | 4.1.92.Final | 4.1.93.Final | 4.1.112.Final | 4.1.117.Final | 4.1.130.Final",
+        versions: "3.10.6.Final | 4.1.115.Final | 4.1.48.Final | 4.1.49.Final | 4.1.52.Final | 4.1.58.Final | 4.1.60.Final | 4.1.63.Final | 4.1.73.Final | 4.1.75.Final | 4.1.82.Final | 4.1.92.Final | 4.1.93.Final | 4.1.112.Final | 4.1.117.Final | 4.1.130.Final",
         link: "./java-libraries/",
       },
       {
@@ -482,7 +542,7 @@ const techData = [
       },
       {
         name: "Plexus Utils",
-        versions: "1.4.5 | 1.5.8",
+        versions: "1.4.5 | 1.5.5 | 1.5.8 | 3.1.0 | 3.6.0",
         link: "./java-libraries/",
       },
       {
@@ -492,8 +552,13 @@ const techData = [
       },
       {
         name: "Protobuf",
-        versions: "2.5.0 | 2.6.1 | 3.21.9",
+        versions: "2.5.0 | 2.6.1 | 3.19.6 | 3.21.1 | 3.21.9",
         link: "./protobuf/",
+      },
+      {
+        name: "Quartz Scheduler",
+        versions: "1.8.5",
+        link: "./java-libraries/",
       },
       {
         name: "Querydsl",
@@ -502,12 +567,22 @@ const techData = [
       },
       {
         name: "Reactor BOM",
-        versions: "2020.0.23 | 2020.0.32 | 2020.0.38 | 2022.0.15",
+        versions: "2020.0.0 | 2020.0.7 | 2020.0.23 | 2020.0.32 | 2020.0.38 | 2022.0.15",
         link: "./java-libraries/",
       },
       {
         name: "Reactor Netty",
-        versions: "1.0.23 | 1.0.32 | 1.0.39 | 1.1.15",
+        versions: "1.0.0 | 1.0.7 | 1.0.23 | 1.0.32 | 1.0.39 | 1.1.15",
+        link: "./java-libraries/",
+      },
+      {
+        name: "reload4j",
+        versions: "1.2.16",
+        link: "./java-libraries/",
+      },
+      {
+        name: "Retrofit",
+        versions: "2.9.0",
         link: "./java-libraries/",
       },
       {
@@ -516,13 +591,18 @@ const techData = [
         link: "./java-libraries/",
       },
       {
+        name: "SLF4J",
+        versions: "1.6.1 | 1.7.21",
+        link: "./java-libraries/",
+      },
+      {
         name: "SnakeYAML",
-        versions: "1.23 | 1.26 | 1.29 | 1.30 | 1.33",
+        versions: "1.23 | 1.26 | 1.28 | 1.29 | 1.30 | 1.33",
         link: "./java-libraries/",
       },
       {
         name: "Snappy Java",
-        versions: "1.1.8.4",
+        versions: "1.1.2 | 1.1.8.4",
         link: "./java-libraries/",
       },
       {
@@ -531,8 +611,13 @@ const techData = [
         link: "./java-libraries/",
       },
       {
+        name: "Sonatype Sisu",
+        versions: "2.3.0",
+        link: "./java-libraries/",
+      },
+      {
         name: "Spring® Framework",
-        versions: "3.1 | 4.0 | 4.1 | 4.3 | 5.2 | 5.3 | 6.0 | 6.1",
+        versions: "3.0 | 3.1 | 4.0 | 4.1 | 4.2 | 4.3 | 5.1 | 5.2 | 5.3 | 6.0 | 6.1 | 6.2",
         link: "./spring/",
         detailsHash: "Framework",
       },
@@ -548,13 +633,13 @@ const techData = [
       },
       {
         name: "Spring® Boot",
-        versions: "2.4 | 2.6 | 2.7 | 3.1",
+        versions: "2.1 | 2.3 | 2.4 | 2.5 | 2.6 | 2.7 | 3.0 | 3.1 | 3.2 | 3.3 | 3.4",
         link: "./spring/",
         detailsHash: "Boot",
       },
       {
         name: "Spring® Cloud",
-        versions: "3.1.9",
+        versions: "3.1.6 | 3.1.9",
         link: "./spring/",
       },
       {
@@ -565,7 +650,7 @@ const techData = [
       },
       {
         name: "Spring® Security",
-        versions: "5.7 | 5.8 | 6.1",
+        versions: "1.3 | 4.2 | 5.6 | 5.7 | 5.8 | 6.1 | 6.2 | 6.3 | 6.4",
         link: "./spring/",
         detailsHash: "Security",
       },
@@ -591,7 +676,7 @@ const techData = [
       },
       {
         name: "Spring® LDAP",
-        versions: "2.4.1 | 2.4.4",
+        versions: "2.4.1 | 2.4.4 | 3.0.6",
         link: "./spring/",
         detailsHash: "LDAP",
       },
@@ -632,12 +717,22 @@ const techData = [
       },
       {
         name: "Undertow",
-        versions: "2.2.33.Final | 2.3.0.Final | 2.3.10.Final | 2.3.18.Final",
+        versions: "2.2.28.Final | 2.2.33.Final | 2.2.37.Final | 2.3.0.Final | 2.3.10.Final | 2.3.18.Final",
+        link: "./java-libraries/",
+      },
+      {
+        name: "WildFly",
+        versions: "27.0.1.Final",
+        link: "./java-libraries/",
+      },
+      {
+        name: "WildFly Core",
+        versions: "19.0.1.Final",
         link: "./java-libraries/",
       },
       {
         name: "Woodstox",
-        versions: "5.0.3",
+        versions: "5.0.3 | 5.3.0",
         link: "./java-libraries/",
       },
       {

--- a/docs/els-for-libraries/apache-cxf/README.md
+++ b/docs/els-for-libraries/apache-cxf/README.md
@@ -4,7 +4,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Apache CXF provides security patch
 
 ## Supported Versions
 
-* Apache CXF 3.5.9, 3.5.11
+* Apache CXF 3.4.5, 3.5.9, 3.5.11
 
 ## Installation
 

--- a/docs/els-for-libraries/apache-kafka/README.md
+++ b/docs/els-for-libraries/apache-kafka/README.md
@@ -8,7 +8,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Apache Kafka® provides security p
 
 ## Supported Versions
 
-* Apache Kafka® 3.2.3, 3.7.1
+* Apache Kafka® 2.8.2, 3.2.3, 3.7.1
 
 ## Installation
 

--- a/docs/els-for-libraries/apache-log4j/README.md
+++ b/docs/els-for-libraries/apache-log4j/README.md
@@ -4,7 +4,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Apache Log4j provides security pat
 
 ## Supported Versions
 
-* Apache Log4j 1.2.16, 1.2.17, 2.17.1, 2.22.1
+* Apache Log4j 1.2.16, 1.2.17, 2.17.1, 2.17.2, 2.22.1
 
 ## Installation
 

--- a/docs/els-for-libraries/apache-velocity-engine/README.md
+++ b/docs/els-for-libraries/apache-velocity-engine/README.md
@@ -8,7 +8,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Apache Velocity Engine™ provides
 
 ## Supported Versions
 
-* Apache Velocity Engine™ 1.7
+* Apache Velocity Engine™ 1.7, 1.7.1
 
 ## Installation
 

--- a/docs/els-for-libraries/hibernate/README.md
+++ b/docs/els-for-libraries/hibernate/README.md
@@ -4,7 +4,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Hibernate provides security patche
 
 ## Supported Versions
 
-* Hibernate ORM 4.3.11.Final, 5.4.3.Final, 5.4.30.Final, 5.4.31.Final, 5.4.32.Final, 5.4.33.Final, 5.5.6.Final, 5.5.9.Final, 5.6.15.Final, 6.2.5.Final
+* Hibernate ORM 4.3.11.Final, 5.1.2.Final, 5.4.3.Final, 5.4.30.Final, 5.4.31.Final, 5.4.32.Final, 5.4.33.Final, 5.5.6.Final, 5.5.9.Final, 5.6.15.Final, 6.2.5.Final
 * Hibernate Search 5.11.10.Final
 
 ## Installation

--- a/docs/els-for-libraries/hibernate/README.md
+++ b/docs/els-for-libraries/hibernate/README.md
@@ -4,8 +4,10 @@ TuxCare's Endless Lifecycle Support (ELS) for Hibernate provides security patche
 
 ## Supported Versions
 
+* Hibernate Commons Annotations 5.1.2.Final
 * Hibernate ORM 4.3.11.Final, 5.1.2.Final, 5.4.3.Final, 5.4.30.Final, 5.4.31.Final, 5.4.32.Final, 5.4.33.Final, 5.5.6.Final, 5.5.9.Final, 5.6.15.Final, 6.2.5.Final
 * Hibernate Search 5.11.10.Final
+* Hibernate Validator 5.4.3.Final, 6.2.5.Final
 
 ## Installation
 

--- a/docs/els-for-libraries/jackson/README.md
+++ b/docs/els-for-libraries/jackson/README.md
@@ -4,7 +4,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Jackson provides security patches 
 
 ## Supported Versions
 
-* Jackson 1.9.13, 2.14.2
+* Jackson 1.9.13, 2.12.1, 2.14.1, 2.14.2
 
 ## Installation
 

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -50,8 +50,6 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Grails** 2.5.6, 6.2.3
 * **H2 Database** 1.4.200
 * **Hazelcast** 4.2.8
-* **Hibernate Commons Annotations** 5.1.2.Final
-* **Hibernate Validator** 5.4.3.Final, 6.2.5.Final
 * **HornetQ** 2.4.9.Final
 * **HPPC** 0.8.1
 * **HtmlUnit** 2.70.0
@@ -84,7 +82,6 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Querydsl** 5.1.0
 * **Reactor BOM** 2020.0.0, 2020.0.7, 2020.0.23, 2020.0.32, 2020.0.38, 2022.0.15
 * **Reactor Netty** 1.0.0, 1.0.7, 1.0.23, 1.0.32, 1.0.39, 1.1.15
-* **reload4j** 1.2.16
 * **Retrofit** 2.9.0
 * **RSocket** 1.1.3
 * **SLF4J** 1.6.1, 1.7.21
@@ -95,7 +92,6 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Thymeleaf** 3.0.15.RELEASE
 * **Undertow** 2.2.28.Final, 2.2.33.Final, 2.2.37.Final, 2.3.0.Final, 2.3.10.Final, 2.3.18.Final
 * **WildFly** 27.0.1.Final
-* **WildFly Core** 19.0.1.Final
 * **Woodstox** 5.0.3, 5.3.0
 * **Xerces** 2.11.0, 2.12.0
 * **XMLUnit** 2.9.1, 2.9.0

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -8,7 +8,6 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Apache ActiveMQ Artemis** 2.26.0, 2.33.0
 * **Apache Avro** 1.7.6, 1.7.7, 1.8.2, 1.10.2, 1.11.0, 1.11.3
 * **Apache Axis** 1.4
-* **Apache Batik** 1.7
 * **Apache Commons BeanUtils** 1.6, 1.8.0, 1.8.3, 1.9.4, 1.10.1
 * **Apache Commons Collections** 3.2, 3.2.1
 * **Apache Commons Compress** 1.18, 1.19, 1.20, 1.21, 1.26.2
@@ -27,6 +26,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Apache Thrift** 0.9.1, 0.9.3, 0.14.1
 * **Apache Tika** 2.9.4
 * **Apache Xalan** 2.7.1
+* **Apache XML Graphics Batik** 1.7
 * **Apache XML Graphics Commons** 1.4, 2.1
 * **Apache XMLBeans** 2.3.0, 2.6.0
 * **AssertJ** 2.9.0, 3.18.1, 3.25.3

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -4,26 +4,31 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 
 ## Supported Java Libraries
 
-* **Apache ActiveMQ Artemis** 2.26.0
+* **Aircompressor** 0.27
+* **Apache ActiveMQ Artemis** 2.26.0, 2.33.0
 * **Apache Avro** 1.7.6, 1.7.7, 1.8.2, 1.10.2, 1.11.0, 1.11.3
 * **Apache Axis** 1.4
+* **Apache Batik** 1.7
 * **Apache Commons BeanUtils** 1.6, 1.8.0, 1.8.3, 1.9.4, 1.10.1
+* **Apache Commons Collections** 3.2, 3.2.1
 * **Apache Commons Compress** 1.18, 1.19, 1.20, 1.21, 1.26.2
 * **Apache Commons Digester** 2.0, 2.1
-* **Apache Commons FileUpload** 1.2.1, 1.2.2
+* **Apache Commons FileUpload** 1.2.1, 1.2.2, 1.5
 * **Apache Commons HttpClient** 3.1
 * **Apache Commons IO** 2.4, 2.5, 2.6, 2.7, 2.8.0, 2.11.0
 * **Apache Commons VFS** 2.0
 * **Apache FOP** 1.0
 * **Apache HttpComponents Client** 4.5.2
+* **Apache Ivy** 2.3.0
 * **Apache Neethi** 3.1.1
 * **Apache POI** 3.10-FINAL, 4.1.2
 * **Apache Pulsar** 3.2.4
 * **Apache Santuario XML Security For Java** 2.0.10, 2.3.1
 * **Apache Thrift** 0.9.1, 0.9.3, 0.14.1
 * **Apache Tika** 2.9.4
+* **Apache Xalan** 2.7.1
 * **Apache XML Graphics Commons** 1.4, 2.1
-* **Apache XMLBeans** 2.6.0
+* **Apache XMLBeans** 2.3.0, 2.6.0
 * **AssertJ** 2.9.0, 3.18.1, 3.25.3
 * **Apereo CAS Client** 4.0.4
 * **Bouncy Castle** 1.64, 1.76, 1.78.1
@@ -35,7 +40,9 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Eclipse Parsson** 1.0.0
 * **EdDSA** 0.3.0
 * **el-spec** 3.0.0
+* **EWS Java API** 2.0
 * **excel-streaming-reader** 5.0.2
+* **GlassFish** 3.0.0
 * **Google Gson** 2.4, 2.8.5, 2.8.9, 2.9.1, 2.10.1, 2.11.0
 * **Google Guava** 16.0.1, 18.0, 20.0, 25.1-android, 25.1-jre, 27.1-android, 27.1-jre, 30.1-jre, 31.1-jre
 * **Google Guice** 4.2.1
@@ -43,41 +50,53 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Grails** 2.5.6, 6.2.3
 * **H2 Database** 1.4.200
 * **Hazelcast** 4.2.8
+* **Hibernate Commons Annotations** 5.1.2.Final
+* **Hibernate Validator** 5.4.3.Final, 6.2.5.Final
 * **HornetQ** 2.4.9.Final
 * **HPPC** 0.8.1
 * **HtmlUnit** 2.70.0
 * **iText** 2.1.7
-* **JasperReports** 3.7.4
+* **JasperReports** 3.7.4, 6.2.2, 6.21.5
 * **JBoss XNIO** 3.8.0, 3.8.8
 * **JDOM** 1.0, 1.1.3
 * **Joda-Time** 1.3
 * **JSON** 20090211, 20140107
 * **JSON Assert** 1.2.3
-* **JSON Smart v2** 2.4.8
+* **JSON Smart v2** 1.3.2, 2.4.8
+* **json-io** 2.9.4
+* **jsoup** 1.7.2
 * **JUnit** 4.13
 * **Logback** 1.1.7, 1.2.13, 1.4.14, 1.5.18
 * **LZ4** 1.8.1
 * **mchange-commons-java** 0.2.15, 0.2.19, 0.2.20
 * **Mozilla Rhino** 1.7.10, 1.7.15
 * **MyBatis** 2.3.5
+* **MySQL Connector/J** 5.1.49
 * **NekoHTML** 1.9.22
-* **Netty** 4.1.115.Final, 4.1.48.Final, 4.1.49.Final, 4.1.52.Final, 4.1.58.Final, 4.1.60.Final, 4.1.63.Final, 4.1.73.Final, 4.1.75.Final, 4.1.82.Final, 4.1.92.Final, 4.1.93.Final, 4.1.112.Final, 4.1.117.Final, 4.1.130.Final
+* **Netty** 3.10.6.Final, 4.1.115.Final, 4.1.48.Final, 4.1.49.Final, 4.1.52.Final, 4.1.58.Final, 4.1.60.Final, 4.1.63.Final, 4.1.73.Final, 4.1.75.Final, 4.1.82.Final, 4.1.92.Final, 4.1.93.Final, 4.1.112.Final, 4.1.117.Final, 4.1.130.Final
 * **Netty Incubator** 0.0.21.Final
 * **Nimbus JOSE + JWT** 8.23, 9.22, 9.23, 9.24.4, 9.37.3, 9.39.3
 * **Nimbus OAuth2 OIDC SDK** 9.43.3, 9.43.6
 * **OkHttp3** 3.14.9, 4.10.0
 * **Okio** 2.8.0, 2.10.0
-* **Plexus Utils** 1.4.5, 1.5.8
+* **Plexus Utils** 1.4.5, 1.5.5, 1.5.8, 3.1.0, 3.6.0
+* **Quartz Scheduler** 1.8.5
 * **Querydsl** 5.1.0
-* **Reactor BOM** 2020.0.23, 2020.0.32, 2020.0.38, 2022.0.15
-* **Reactor Netty** 1.0.23, 1.0.32, 1.0.39, 1.1.15
+* **Reactor BOM** 2020.0.0, 2020.0.7, 2020.0.23, 2020.0.32, 2020.0.38, 2022.0.15
+* **Reactor Netty** 1.0.0, 1.0.7, 1.0.23, 1.0.32, 1.0.39, 1.1.15
+* **reload4j** 1.2.16
+* **Retrofit** 2.9.0
 * **RSocket** 1.1.3
-* **SnakeYAML** 1.23, 1.26, 1.29, 1.30, 1.33
-* **Snappy Java** 1.1.8.4
+* **SLF4J** 1.6.1, 1.7.21
+* **SnakeYAML** 1.23, 1.26, 1.28, 1.29, 1.30, 1.33
+* **Snappy Java** 1.1.2, 1.1.8.4
 * **Sonatype Aether** 1.13.1
+* **Sonatype Sisu** 2.3.0
 * **Thymeleaf** 3.0.15.RELEASE
-* **Undertow** 2.2.33.Final, 2.3.0.Final, 2.3.10.Final, 2.3.18.Final
-* **Woodstox** 5.0.3
+* **Undertow** 2.2.28.Final, 2.2.33.Final, 2.2.37.Final, 2.3.0.Final, 2.3.10.Final, 2.3.18.Final
+* **WildFly** 27.0.1.Final
+* **WildFly Core** 19.0.1.Final
+* **Woodstox** 5.0.3, 5.3.0
 * **Xerces** 2.11.0, 2.12.0
 * **XMLUnit** 2.9.1, 2.9.0
 * **XStream** 1.4.17

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -91,7 +91,6 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Sonatype Sisu** 2.3.0
 * **Thymeleaf** 3.0.15.RELEASE
 * **Undertow** 2.2.28.Final, 2.2.33.Final, 2.2.37.Final, 2.3.0.Final, 2.3.10.Final, 2.3.18.Final
-* **WildFly** 27.0.1.Final
 * **Woodstox** 5.0.3, 5.3.0
 * **Xerces** 2.11.0, 2.12.0
 * **XMLUnit** 2.9.1, 2.9.0

--- a/docs/els-for-libraries/protobuf/README.md
+++ b/docs/els-for-libraries/protobuf/README.md
@@ -4,7 +4,7 @@ TuxCare's Endless Lifecycle Support (ELS) for Protobuf provides security patches
 
 ## Supported Versions
 
-* Protobuf 2.5.0, 2.6.1, 3.21.9
+* Protobuf 2.5.0, 2.6.1, 3.19.6, 3.21.1, 3.21.9
 
 ## Installation
 

--- a/docs/els-for-libraries/spring/README.md
+++ b/docs/els-for-libraries/spring/README.md
@@ -39,34 +39,34 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-core | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-jcl | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-context | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-beans | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-expression | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-jms | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-messaging | 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-aop | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-context-support | 3.1.1.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-tx | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-orm | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-aspects | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-r2dbc | 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-jdbc | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-web | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-webmvc | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-oxm | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-webflux | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-websocket | 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-framework-bom | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.21 |
-| spring-context-indexer | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-instrument | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-test | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-core-test | 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-webmvc-portlet | 4.3.30.RELEASE |
-| spring-instrument-tomcat | 4.3.30.RELEASE |
+| spring-core | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-jcl | 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-context | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-beans | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-expression | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-jms | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-messaging | 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-aop | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-context-support | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-tx | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-orm | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-aspects | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-r2dbc | 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-jdbc | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-web | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-webmvc | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-oxm | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-webflux | 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-websocket | 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-framework-bom | 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.21, 6.2.15 |
+| spring-context-indexer | 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-instrument | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-test | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-core-test | 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-webmvc-portlet | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE |
+| spring-instrument-tomcat | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE |
 | spring | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31 |
-| framework-docs | 6.0.16, 6.1.21 |
+| framework-docs | 6.0.16, 6.1.21, 6.2.15 |
 </template>
 
 <template #AMQP>
@@ -99,84 +99,84 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-boot | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-actuator | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-actuator-autoconfigure | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-autoconfigure | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-amqp | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-json | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-logging | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-reactor-netty | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-rsocket | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-tomcat | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-validation | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-web | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-webflux | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-autoconfigure-processor | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-configuration-processor | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-test | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-test-autoconfigure | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-mongodb-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-graphql | 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-cli | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-dependencies | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-devtools | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-parent | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-properties-migrator | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-activemq | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-actuator | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-aop | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-artemis | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-batch | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-cache | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-cassandra | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-cassandra-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-couchbase | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-couchbase-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-elasticsearch | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-jdbc | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-jpa | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-ldap | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-mongodb | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-neo4j | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-r2dbc | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-redis | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-rest | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-freemarker | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-groovy-templates | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-hateoas | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-integration | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-jdbc | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-jersey | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-jetty | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-jooq | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-jta-atomikos | 2.4.5, 2.4.6, 2.7.16, 2.7.18 |
-| spring-boot-starter-log4j2 | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-mail | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-mustache | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-oauth2-client | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-oauth2-resource-server | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-parent | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-quartz | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-security | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-thymeleaf | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-undertow | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-web-services | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-websocket | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-antlib | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-buildpack-platform | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-configuration-metadata | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-gradle-plugin | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-jarmode-layertools | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-loader | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-loader-tools | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-maven-plugin | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-redis-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-test | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-solr | 2.4.5, 2.4.6 |
-| org.springframework.boot.gradle.plugin | 2.4.5, 2.4.6, 3.1.8 |
-| spring-boot-starter-jta-bitronix | 2.4.5, 2.4.6 |
+| spring-boot | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-actuator | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-actuator-autoconfigure | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-autoconfigure | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-amqp | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-json | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-logging | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-reactor-netty | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-rsocket | 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-tomcat | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-validation | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-web | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-webflux | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-autoconfigure-processor | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-configuration-processor | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.6.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-test | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-test-autoconfigure | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-mongodb-reactive | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-graphql | 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-cli | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-dependencies | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-devtools | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-parent | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-properties-migrator | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-activemq | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-actuator | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-aop | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-artemis | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-batch | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-cache | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-cassandra | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-cassandra-reactive | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-couchbase | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-couchbase-reactive | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-elasticsearch | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-jdbc | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-jpa | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-ldap | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-mongodb | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-neo4j | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-r2dbc | 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-redis | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-rest | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-freemarker | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-groovy-templates | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-hateoas | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-integration | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-jdbc | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-jersey | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-jetty | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-jooq | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-jta-atomikos | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18 |
+| spring-boot-starter-log4j2 | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-mail | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-mustache | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-oauth2-client | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-oauth2-resource-server | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-parent | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-quartz | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-security | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-thymeleaf | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-undertow | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-web-services | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-websocket | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-antlib | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-buildpack-platform | 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-configuration-metadata | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-gradle-plugin | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-jarmode-layertools | 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12 |
+| spring-boot-loader | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-loader-tools | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-maven-plugin | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-redis-reactive | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-test | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 2.7.18, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-data-solr | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6 |
+| org.springframework.boot.gradle.plugin | 2.3.6.RELEASE, 2.4.5, 2.4.6, 2.5.15, 2.7.16, 3.0.13, 3.1.8, 3.2.12, 3.3.13, 3.4.13 |
+| spring-boot-starter-jta-bitronix | 2.1.8.RELEASE, 2.3.6.RELEASE, 2.4.5, 2.4.6 |
 </template>
 
 <template #Cloud>
@@ -188,13 +188,13 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 | spring-cloud-build-tools | 3.1.6, 3.1.9 |
 | spring-cloud-build-docs | 3.1.6, 3.1.9 |
 | spring-cloud-dependencies-parent | 3.1.6, 3.1.9 |
-| spring-cloud-gateway | 3.1.6, 3.1.9 |
-| spring-cloud-gateway-dependencies | 3.1.6, 3.1.9 |
-| spring-cloud-gateway-server | 3.1.6, 3.1.9 |
-| spring-cloud-gateway-webflux | 3.1.6, 3.1.9 |
-| spring-cloud-gateway-mvc | 3.1.6, 3.1.9 |
-| spring-cloud-gateway-docs | 3.1.6, 3.1.9 |
-| spring-cloud-starter-gateway | 3.1.6, 3.1.9 |
+| spring-cloud-gateway | 3.1.9 |
+| spring-cloud-gateway-dependencies | 3.1.9 |
+| spring-cloud-gateway-server | 3.1.9 |
+| spring-cloud-gateway-webflux | 3.1.9 |
+| spring-cloud-gateway-mvc | 3.1.9 |
+| spring-cloud-gateway-docs | 3.1.9 |
+| spring-cloud-starter-gateway | 3.1.9 |
 </template>
 
 <template #Data>
@@ -236,27 +236,27 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 | Module | Version |
 |---|---|
 | spring-security | 5.7.11, 5.7.12, 5.7.14, 5.8.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-bom | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-core | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-config | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-web | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-crypto | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-data | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-ldap | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-messaging | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-oauth2-client | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-oauth2-core | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-oauth2-jose | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-oauth2-resource-server | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-rsocket | 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-saml2-service-provider | 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-test | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-acl | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-aspects | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-cas | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-remoting | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16 |
-| spring-security-taglibs | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-openid | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16 |
+| spring-security-bom | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-core | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-config | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-web | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-crypto | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-data | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-ldap | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-messaging | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-oauth2-client | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-oauth2-core | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-oauth2-jose | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-oauth2-resource-server | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-rsocket | 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-saml2-service-provider | 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-test | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-acl | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-aspects | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-cas | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-remoting | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16 |
+| spring-security-taglibs | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-openid | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16 |
 </template>
 
 <template #Security_OAuth>
@@ -334,14 +334,14 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-ldap-core | 2.4.1, 2.4.4 |
-| spring-ldap-odm | 2.4.4 |
-| spring-ldap-test | 2.4.4 |
-| spring-ldap-sandbox | 2.4.4 |
-| spring-ldap-ldif-core | 2.4.4 |
+| spring-ldap-core | 2.4.1, 2.4.4, 3.0.6 |
+| spring-ldap-odm | 2.4.4, 3.0.6 |
+| spring-ldap-test | 2.4.4, 3.0.6 |
+| spring-ldap-sandbox | 2.4.4, 3.0.6 |
+| spring-ldap-ldif-core | 2.4.4, 3.0.6 |
 | spring-ldap-core-tiger | 2.4.4 |
-| spring-ldap-odm-sample | 2.4.4 |
-| spring-ldap-plain-sample | 2.4.4 |
+| spring-ldap-odm-sample | 2.4.4, 3.0.6 |
+| spring-ldap-plain-sample | 2.4.4, 3.0.6 |
 </template>
 
 <template #GraphQL>
@@ -395,7 +395,7 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-security-oauth2-authorization-server | 1.1.4 |
+| spring-security-oauth2-authorization-server | 1.1.4, 1.3.7 |
 </template>
 
 </TableTabs>

--- a/docs/els-for-libraries/spring/README.md
+++ b/docs/els-for-libraries/spring/README.md
@@ -39,33 +39,33 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-core | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-jcl | 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-context | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-beans | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-expression | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-jms | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-messaging | 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-aop | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-context-support | 3.1.1.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-tx | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-orm | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-aspects | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-r2dbc | 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-jdbc | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-web | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-webmvc | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-oxm | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-webflux | 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-websocket | 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-framework-bom | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.21 |
-| spring-context-indexer | 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-instrument | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
-| spring-test | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-core | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-jcl | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-context | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-beans | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-expression | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-jms | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-messaging | 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-aop | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-context-support | 3.1.1.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-tx | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-orm | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-aspects | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-r2dbc | 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-jdbc | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-web | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-webmvc | 3.1.1.RELEASE, 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-oxm | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-webflux | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-websocket | 4.0.0.RELEASE, 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-framework-bom | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.21 |
+| spring-context-indexer | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-instrument | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
+| spring-test | 4.3.30.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
 | spring-core-test | 6.0.16, 6.0.23, 6.1.20, 6.1.21 |
 | spring-webmvc-portlet | 4.3.30.RELEASE |
 | spring-instrument-tomcat | 4.3.30.RELEASE |
-| spring | 5.2.0.RELEASE, 5.3.27, 5.3.29, 5.3.30, 5.3.31 |
+| spring | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31 |
 | framework-docs | 6.0.16, 6.1.21 |
 </template>
 
@@ -99,81 +99,81 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-boot | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-actuator | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-actuator-autoconfigure | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-autoconfigure | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-amqp | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-json | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-logging | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-reactor-netty | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-rsocket | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-tomcat | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-validation | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-web | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-webflux | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-autoconfigure-processor | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-configuration-processor | 2.4.5, 2.4.6, 2.6.15, 2.7.18, 3.1.8 |
-| spring-boot-starter-test | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-test-autoconfigure | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-mongodb-reactive | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-graphql | 2.7.18, 3.1.8 |
-| spring-boot-cli | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-dependencies | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-devtools | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-parent | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-properties-migrator | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-activemq | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-actuator | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-aop | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-artemis | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-batch | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-cache | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-cassandra | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-cassandra-reactive | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-couchbase | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-couchbase-reactive | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-elasticsearch | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-jdbc | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-jpa | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-ldap | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-mongodb | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-neo4j | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-r2dbc | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-redis | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-rest | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-freemarker | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-groovy-templates | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-hateoas | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-integration | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-jdbc | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-jersey | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-jetty | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-jooq | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-jta-atomikos | 2.4.5, 2.4.6, 2.7.18 |
-| spring-boot-starter-log4j2 | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-mail | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-mustache | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-oauth2-client | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-oauth2-resource-server | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-parent | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-quartz | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-security | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-thymeleaf | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-undertow | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-web-services | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-websocket | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-antlib | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-buildpack-platform | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-configuration-metadata | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-gradle-plugin | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-jarmode-layertools | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-loader | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-loader-tools | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-maven-plugin | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-starter-data-redis-reactive | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
-| spring-boot-test | 2.4.5, 2.4.6, 2.7.18, 3.1.8 |
+| spring-boot | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-actuator | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-actuator-autoconfigure | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-autoconfigure | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-amqp | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-json | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-logging | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-reactor-netty | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-rsocket | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-tomcat | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-validation | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-web | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-webflux | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-autoconfigure-processor | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-configuration-processor | 2.4.5, 2.4.6, 2.6.15, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-test | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-test-autoconfigure | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-mongodb-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-graphql | 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-cli | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-dependencies | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-devtools | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-parent | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-properties-migrator | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-activemq | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-actuator | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-aop | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-artemis | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-batch | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-cache | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-cassandra | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-cassandra-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-couchbase | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-couchbase-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-elasticsearch | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-jdbc | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-jpa | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-ldap | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-mongodb | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-neo4j | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-r2dbc | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-redis | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-rest | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-freemarker | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-groovy-templates | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-hateoas | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-integration | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-jdbc | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-jersey | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-jetty | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-jooq | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-jta-atomikos | 2.4.5, 2.4.6, 2.7.16, 2.7.18 |
+| spring-boot-starter-log4j2 | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-mail | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-mustache | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-oauth2-client | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-oauth2-resource-server | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-parent | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-quartz | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-security | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-thymeleaf | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-undertow | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-web-services | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-websocket | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-antlib | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-buildpack-platform | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-configuration-metadata | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-gradle-plugin | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-jarmode-layertools | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-loader | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-loader-tools | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-maven-plugin | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-starter-data-redis-reactive | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
+| spring-boot-test | 2.4.5, 2.4.6, 2.7.16, 2.7.18, 3.1.8 |
 | spring-boot-starter-data-solr | 2.4.5, 2.4.6 |
 | org.springframework.boot.gradle.plugin | 2.4.5, 2.4.6, 3.1.8 |
 | spring-boot-starter-jta-bitronix | 2.4.5, 2.4.6 |
@@ -183,18 +183,18 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-cloud-build | 3.1.9 |
-| spring-cloud-build-dependencies | 3.1.9 |
-| spring-cloud-build-tools | 3.1.9 |
-| spring-cloud-build-docs | 3.1.9 |
-| spring-cloud-dependencies-parent | 3.1.9 |
-| spring-cloud-gateway | 3.1.9 |
-| spring-cloud-gateway-dependencies | 3.1.9 |
-| spring-cloud-gateway-server | 3.1.9 |
-| spring-cloud-gateway-webflux | 3.1.9 |
-| spring-cloud-gateway-mvc | 3.1.9 |
-| spring-cloud-gateway-docs | 3.1.9 |
-| spring-cloud-starter-gateway | 3.1.9 |
+| spring-cloud-build | 3.1.6, 3.1.9 |
+| spring-cloud-build-dependencies | 3.1.6, 3.1.9 |
+| spring-cloud-build-tools | 3.1.6, 3.1.9 |
+| spring-cloud-build-docs | 3.1.6, 3.1.9 |
+| spring-cloud-dependencies-parent | 3.1.6, 3.1.9 |
+| spring-cloud-gateway | 3.1.6, 3.1.9 |
+| spring-cloud-gateway-dependencies | 3.1.6, 3.1.9 |
+| spring-cloud-gateway-server | 3.1.6, 3.1.9 |
+| spring-cloud-gateway-webflux | 3.1.6, 3.1.9 |
+| spring-cloud-gateway-mvc | 3.1.6, 3.1.9 |
+| spring-cloud-gateway-docs | 3.1.6, 3.1.9 |
+| spring-cloud-starter-gateway | 3.1.6, 3.1.9 |
 </template>
 
 <template #Data>
@@ -236,27 +236,27 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 | Module | Version |
 |---|---|
 | spring-security | 5.7.11, 5.7.12, 5.7.14, 5.8.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-bom | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-core | 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-config | 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-web | 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-crypto | 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-data | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-ldap | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-messaging | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-bom | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-core | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-config | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-web | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-crypto | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-data | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-ldap | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-messaging | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
 | spring-security-oauth2-client | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
 | spring-security-oauth2-core | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
 | spring-security-oauth2-jose | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
 | spring-security-oauth2-resource-server | 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6 |
 | spring-security-rsocket | 5.8.15, 5.8.16, 6.1.6 |
 | spring-security-saml2-service-provider | 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-test | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-acl | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-aspects | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-cas | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-remoting | 4.2.20.RELEASE, 5.8.15, 5.8.16 |
-| spring-security-taglibs | 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-openid | 4.2.20.RELEASE, 5.8.15, 5.8.16 |
+| spring-security-test | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-acl | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-aspects | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-cas | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-remoting | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16 |
+| spring-security-taglibs | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16, 6.1.6 |
+| spring-security-openid | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.8.15, 5.8.16 |
 </template>
 
 <template #Security_OAuth>


### PR DESCRIPTION
Backfill base upstream versions present in the els_java Nexus group repo but missing from the docs, per the ELS Java documentation gap inventory.

- java-libraries catch-all README: 14 version bumps to existing entries plus 19 new library entries (alphabetical).
- Dedicated pages: jackson, protobuf, hibernate, apache-cxf, apache-kafka, apache-log4j, apache-velocity-engine.
- ELSTechnology.vue (Java ecosystem): matching version-string bumps and 19 new product rows; Spring family-level strings updated.
- Spring page: backfill patch releases into module rows that already track the same minor line (Framework 4.1.x/5.3.x, Boot 2.7.x, Cloud 3.1.x, Security 4.2.x). New Spring minor lines are reflected at family level in ELSTechnology.vue only.

Dropped 3 gap entries already documented (Apache XML Graphics Commons, H2 Database, JSON Assert). New-minor Spring versions and a few ambiguous new packages are flagged for Nexus/VEX per-module verification.
