### PR TITLE
404 error: remove Machine-Readable Security Data card from What's Next

### DIFF
--- a/docs/securechain/README.md
+++ b/docs/securechain/README.md
@@ -70,7 +70,6 @@ It delivers 24/7/365 access to TuxCare's support team through the [TuxCare Suppo
 
 <WhatsNext hide-title>
 
-* ![](/images/shield-alert.webp) [Machine-Readable Security Data](./machine-readable-security-data/) — SBOM and VEX feeds, formats, and consumption guidance
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/) — Track vulnerability fixes and updates
 
 </WhatsNext>


### PR DESCRIPTION
The What's Next block linked to ./machine-readable-security-data/, but that page does not exist under docs/securechain/ and returns 404. Remove the card.