### PR TITLE
Remove 'system enhancement patches' from ELS OS and Spring descriptions

### DIFF
--- a/docs/els-for-libraries/spring/README.md
+++ b/docs/els-for-libraries/spring/README.md
@@ -4,7 +4,7 @@ Spring® is a trademark of Broadcom Inc. and/or its subsidiaries.
 
 <br>
 
-TuxCare's Endless Lifecycle Support (ELS) for Spring® provides security updates, system enhancement patches, and selected bug fixes that are integral to the stable operation of applications running on these versions of Spring® ecosystem components. These components have either reached their end of standard support from vendors or have reached End of Life (EOL).
+TuxCare's Endless Lifecycle Support (ELS) for Spring® provides security updates and selected bug fixes that are integral to the stable operation of applications running on these versions of Spring® ecosystem components. These components have either reached their end of standard support from vendors or have reached End of Life (EOL).
 
 Our ELS for Spring® service is designed to provide solutions for organizations that are not yet ready to migrate to newer versions and that are seeking long-term stability for their legacy Spring® applications.
 

--- a/docs/els-for-os/README.md
+++ b/docs/els-for-os/README.md
@@ -1,6 +1,6 @@
 # Endless Lifecycle Support for OS
 
-TuxCare's [Endless Lifecycle Support (ELS) for OS](https://tuxcare.com/extended-lifecycle-support/) service provides security updates, system enhancement patches, and selected bug fixes for older versions of a variety of Linux distributions. These distributions have either reached their end of standard support from vendors or have reached End of Life (EOL).
+TuxCare's [Endless Lifecycle Support (ELS) for OS](https://tuxcare.com/extended-lifecycle-support/) service provides security updates and selected bug fixes for older versions of a variety of Linux distributions. These distributions have either reached their end of standard support from vendors or have reached End of Life (EOL).
 
 Our ELS service is designed to provide solutions for organizations that are not yet ready to migrate to newer versions and that are seeking long-term stability for their out-of-date operating systems. The service coverage includes updates for the Linux kernel and a list of essential packages that are integral to server operations.
 


### PR DESCRIPTION
Removed the 'system enhancement patches' wording from the ELS for OS and ELS for Spring service descriptions. Keeping it raises questions about how we guarantee compatibility and avoid customer lock-in when updating system packages, so the service is now described as providing security updates and selected bug fixes only.

Discussed with Artem Karasev and Aleksey Deyneko.
