### PR TITLE
ELSDOC-364: add net-new JS/Java ELS versions (2026-07-27..07-30)

### DIFF
--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -171,7 +171,7 @@ const techData = [
       },
       {
         name: "Apache HttpComponents Client",
-        versions: "4.5.2 | 4.5.8",
+        versions: "4.5.2 | 4.5.6 | 4.5.8 | 4.5.9 | 4.5.10",
         link: "./java-libraries/",
       },
       {
@@ -633,7 +633,7 @@ const techData = [
       },
       {
         name: "Spring® AMQP",
-        versions: "2.4.17",
+        versions: "2.1.8.RELEASE | 2.3.16 | 2.4.17 | 3.1.8",
         link: "./spring/",
       },
       {
@@ -671,7 +671,7 @@ const techData = [
       },
       {
         name: "Spring® Web Services",
-        versions: "3.1.8",
+        versions: "3.1.8 | 4.0.17",
         link: "./spring/",
       },
       {
@@ -913,7 +913,7 @@ const techData = [
       },
       {
         name: "brace-expansion",
-        versions: "1.1.11 | 1.1.12 | 2.0.1",
+        versions: "1.1.11 | 1.1.12 | 2.0.1 | 2.1.2",
         link: "./javascript-libraries/",
       },
       {
@@ -1132,6 +1132,11 @@ const techData = [
         link: "./javascript-libraries/",
       },
       {
+        name: "find-my-way",
+        versions: "9.6.0",
+        link: "./javascript-libraries/",
+      },
+      {
         name: "flatted",
         versions: "3.2.9 | 3.3.3",
         link: "./javascript-libraries/",
@@ -1328,7 +1333,7 @@ const techData = [
       },
       {
         name: "karma",
-        versions: "3.0.0 | 4.0.1 | 4.1.0 | 4.4.1 | 5.0.0 | 5.0.9",
+        versions: "1.5.0 | 1.7.0 | 3.0.0 | 4.0.0 | 4.0.1 | 4.1.0 | 4.4.1 | 5.0.0 | 5.0.9",
         link: "./karma/",
       },
       {
@@ -1343,7 +1348,7 @@ const techData = [
       },
       {
         name: "Lodash",
-        versions: "1.3.1 | 2.4.2 | 3.2.0 | 3.10.1 | 4.17.4 | 4.17.5 | 4.17.15 | 4.17.19 | 4.17.21 | 4.18.1 | 4.5.0",
+        versions: "1.3.1 | 2.4.2 | 3.2.0 | 3.10.1 | 4.17.4 | 4.17.5 | 4.17.11 | 4.17.15 | 4.17.19 | 4.17.21 | 4.18.1 | 4.5.0",
         link: "./lodash/",
       },
       {
@@ -1463,7 +1468,7 @@ const techData = [
       },
       {
         name: "multiparty",
-        versions: "3.3.2",
+        versions: "2.2.0 | 3.3.2",
         link: "./javascript-libraries/",
       },
       {
@@ -1573,7 +1578,7 @@ const techData = [
       },
       {
         name: "PostCSS",
-        versions: "5.2.18 | 6.0.23 | 7.0.14 | 7.0.17 | 7.0.21 | 7.0.32 | 7.0.39 | 8.2.15 | 8.3.6 | 8.4.5 | 8.4.14 | 8.4.31 | 8.4.41 | 8.5.6",
+        versions: "5.2.18 | 6.0.23 | 7.0.14 | 7.0.17 | 7.0.21 | 7.0.32 | 7.0.39 | 8.2.13 | 8.2.15 | 8.3.6 | 8.4.5 | 8.4.14 | 8.4.31 | 8.4.41 | 8.5.6",
         link: "./postcss/",
       },
       {
@@ -1583,7 +1588,7 @@ const techData = [
       },
       {
         name: "protobufjs",
-        versions: "2.2.1 | 3.8.2 | 4.1.3 | 5.0.3 | 6.10.2 | 6.11.6",
+        versions: "2.2.1 | 3.8.2 | 4.1.3 | 5.0.0 | 5.0.3 | 6.10.2 | 6.11.6",
         link: "./javascript-libraries/",
       },
       {
@@ -1622,6 +1627,26 @@ const techData = [
         link: "./react-router/",
       },
       {
+        name: "react-server-dom-esm",
+        versions: "0.0.0-13a913d5-20260727",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "react-server-dom-parcel",
+        versions: "19.2.0",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "react-server-dom-turbopack",
+        versions: "19.2.0",
+        link: "./javascript-libraries/",
+      },
+      {
+        name: "react-server-dom-webpack",
+        versions: "19.2.0",
+        link: "./javascript-libraries/",
+      },
+      {
         name: "redis",
         versions: "2.8.0",
         link: "./javascript-libraries/",
@@ -1633,7 +1658,7 @@ const techData = [
       },
       {
         name: "Request",
-        versions: "2.88.0 | 2.88.2",
+        versions: "2.65.0 | 2.88.0 | 2.88.2",
         link: "./javascript-libraries/",
       },
       {
@@ -1678,7 +1703,7 @@ const techData = [
       },
       {
         name: "shelljs",
-        versions: "0.1.4 | 0.3.0 | 0.8.2",
+        versions: "0.1.4 | 0.3.0 | 0.8.2 | 0.8.4",
         link: "./javascript-libraries/",
       },
       {
@@ -1868,7 +1893,7 @@ const techData = [
       },
       {
         name: "ws",
-        versions: "0.8.1 | 1.1.1 | 1.1.2 | 1.1.5 | 3.3.3 | 4.1.0 | 7.4.6",
+        versions: "0.8.1 | 1.1.1 | 1.1.2 | 1.1.5 | 3.3.3 | 4.1.0 | 6.2.1 | 7.4.6 | 7.5.9 | 8.16.0 | 8.18.0 | 8.20.0",
         link: "./javascript-libraries/",
       },
       {
@@ -1888,7 +1913,7 @@ const techData = [
       },
       {
         name: "xmlhttprequest-ssl",
-        versions: "1.5.3 | 1.5.5",
+        versions: "1.5.1 | 1.5.3 | 1.5.5",
         link: "./javascript-libraries/",
       },
       {

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -18,7 +18,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Apache Commons IO** 2.4, 2.5, 2.6, 2.7, 2.8.0, 2.11.0
 * **Apache Commons VFS** 2.0
 * **Apache FOP** 1.0
-* **Apache HttpComponents Client** 4.5.2, 4.5.8
+* **Apache HttpComponents Client** 4.5.2, 4.5.6, 4.5.8, 4.5.9, 4.5.10
 * **Apache Ivy** 2.3.0
 * **Apache Neethi** 3.1.1
 * **Apache POI** 3.10-FINAL, 4.1.2

--- a/docs/els-for-libraries/javascript-libraries/README.md
+++ b/docs/els-for-libraries/javascript-libraries/README.md
@@ -28,7 +28,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **bn.js** 4.11.8, 4.12.0
 * **body-parser** 1.8.4, 1.13.3, 1.14.2, 1.19.0, 1.20.0, 1.20.1, 1.20.2
 * **bower** 1.8.4
-* **brace-expansion** 1.1.11, 1.1.12, 2.0.1
+* **brace-expansion** 1.1.11, 1.1.12, 2.0.1, 2.1.2
 * **braces** 0.1.5, 1.8.5, 2.3.1, 2.3.2, 3.0.2, 3.0.3
 * **browserify-sign** 4.0.4, 4.2.1
 * **browserslist** 4.10.0, 4.13.0, 4.27.0
@@ -69,6 +69,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **fast-xml-parser** 3.14.0, 3.17.5, 3.19.0, 4.2.7, 4.4.0, 4.5.3, 4.5.6, 4.5.7
 * **fastify-middie** 8.3.3
 * **file-type** 17.1.6
+* **find-my-way** 9.6.0
 * **flatted** 3.2.9, 3.3.3
 * **follow-redirects** 0.0.3, 1.0.0, 1.2.6, 1.5.10, 1.15.2, 1.15.3, 1.15.5, 1.15.6, 1.15.9, 1.15.11
 * **form-data** 0.0.8, 0.1.4, 0.2.0, 1.0.0-rc3, 1.0.1, 2.0.0, 2.1.4, 2.3.3, 4.0.0, 4.0.1
@@ -125,7 +126,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **mout** 0.9.1, 0.11.0
 * **ms** 0.3.0, 0.6.2, 0.7.1, 0.7.2, 1.0.0, 2.0.0, 2.1.3
 * **multer** 1.4.5-lts, 1.4.5-lts.1, 1.4.5-lts.2
-* **multiparty** 3.3.2
+* **multiparty** 2.2.0, 3.3.2
 * **mysql** 2.18.1
 * **negotiator** 0.5.3
 * **netmask** 1.0.6
@@ -143,13 +144,17 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **picomatch** 2.3.1, 4.0.1, 4.0.2
 * **piscina** 4.6.1
 * **prismjs** 1.27.0, 1.29.0
-* **protobufjs** 2.2.1, 3.8.2, 4.1.3, 5.0.3, 6.10.2, 6.11.6
+* **protobufjs** 2.2.1, 3.8.2, 4.1.3, 5.0.0, 5.0.3, 6.10.2, 6.11.6
 * **protobufjs-utf8** 1.1.0
 * **pug** 2.0.4
 * **qs** 0.5.1, 0.6.6, 1.0.2, 1.2.2, 2.2.4, 2.2.5, 2.3.3, 2.4.2, 3.1.0, 4.0.0, 5.1.0, 5.2.0, 5.2.1, 6.5.3, 6.5.5, 6.7.0, 6.10.3, 6.10.7, 6.11.0, 6.14.0
 * **quill** 1.3.7
+* **react-server-dom-esm** 0.0.0-13a913d5-20260727
+* **react-server-dom-parcel** 19.2.0
+* **react-server-dom-turbopack** 19.2.0
+* **react-server-dom-webpack** 19.2.0
 * **redis** 2.8.0
-* **request** 2.88.0, 2.88.2
+* **request** 2.65.0, 2.88.0, 2.88.2
 * **rollup** 0.36.3, 0.41.6, 0.56.4, 0.57.1, 0.59.4, 0.63.5, 2.1.0, 2.26.5, 2.38.4, 2.77.3, 2.79.1, 2.79.2, 3.15.0, 4.22.4
 * **sanitize-html** 1.27.5
 * **semver** 2.3.2, 4.3.6, 5.0.3, 5.1.0, 5.3.0, 5.6.0, 6.3.0, 7.0.0, 7.1.3, 7.3.2, 7.3.4, 7.3.5, 7.3.8
@@ -158,7 +163,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **serve-static** 1.10.3
 * **set-value** 2.0.0
 * **shell-quote** 1.4.3, 1.6.1, 1.7.2, 1.7.3
-* **shelljs** 0.1.4, 0.3.0, 0.8.2
+* **shelljs** 0.1.4, 0.3.0, 0.8.2, 0.8.4
 * **socket.io** 2.1.1
 * **socket.io-parser** 3.2.0, 3.3.4, 3.4.3, 4.2.4
 * **sockjs** 0.3.18, 0.3.19
@@ -186,11 +191,11 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **websocket-driver** 0.6.5
 * **websocket-extensions** 0.1.1
 * **word-wrap** 1.2.3
-* **ws** 0.8.1, 1.1.1, 1.1.2, 1.1.5, 3.3.3, 4.1.0, 7.4.6
+* **ws** 0.8.1, 1.1.1, 1.1.2, 1.1.5, 3.3.3, 4.1.0, 6.2.1, 7.4.6, 7.5.9, 8.16.0, 8.18.0, 8.20.0
 * **xlsx** 0.18.5
 * **xml2js** 0.2.6, 0.2.8, 0.4.23
 * **xmldom** 0.1.31, 0.6.0
-* **xmlhttprequest-ssl** 1.5.3, 1.5.5
+* **xmlhttprequest-ssl** 1.5.1, 1.5.3, 1.5.5
 * **y18n** 4.0.0
 * **yaml** 1.10.2, 2.5.0
 * **yargs-parser** 4.2.1, 7.0.0, 10.1.0, 11.1.1, 13.1.2

--- a/docs/els-for-libraries/karma/README.md
+++ b/docs/els-for-libraries/karma/README.md
@@ -4,7 +4,7 @@ Endless Lifecycle Support (ELS) for karma from TuxCare provides security fixes f
 
 ## Supported karma Versions
 
-* karma 3.0.0, 4.0.1, 4.1.0, 4.4.1, 5.0.0, 5.0.9
+* karma 1.5.0, 1.7.0, 3.0.0, 4.0.0, 4.0.1, 4.1.0, 4.4.1, 5.0.0, 5.0.9
 
 ## Installation
 

--- a/docs/els-for-libraries/lodash/README.md
+++ b/docs/els-for-libraries/lodash/README.md
@@ -4,7 +4,7 @@ Endless Lifecycle Support (ELS) for Lodash from TuxCare provides security fixes 
 
 ## Supported Lodash Versions
 
-* Lodash 1.3.1, 2.4.2, 3.10.1, 3.2.0, 4.17.4, 4.17.5, 4.17.15, 4.17.19, 4.17.21, 4.18.1, 4.5.0
+* Lodash 1.3.1, 2.4.2, 3.10.1, 3.2.0, 4.17.4, 4.17.5, 4.17.11, 4.17.15, 4.17.19, 4.17.21, 4.18.1, 4.5.0
 
 ## Installation
 
@@ -144,6 +144,19 @@ Endless Lifecycle Support (ELS) for Lodash from TuxCare provides security fixes 
       },
       "overrides": {
         "lodash@4.17.5": "npm:@els-js/lodash@>=4.17.5-tuxcare.1"
+      }
+      ```
+
+      </template>
+
+      <template #Lodash_4.17.11>
+
+      ```text
+      "dependencies": {
+        "lodash": "npm:@els-js/lodash@>=4.17.11-tuxcare.1"
+      },
+      "overrides": {
+        "lodash@4.17.11": "npm:@els-js/lodash@>=4.17.11-tuxcare.1"
       }
       ```
 

--- a/docs/els-for-libraries/postcss/README.md
+++ b/docs/els-for-libraries/postcss/README.md
@@ -4,7 +4,7 @@ Endless Lifecycle Support (ELS) for PostCSS from TuxCare provides security fixes
 
 ## Supported PostCSS Versions
 
-* PostCSS 5.2.18, 6.0.23, 7.0.14, 7.0.17, 7.0.21, 7.0.32, 7.0.39, 8.2.15, 8.3.6, 8.4.5, 8.4.14, 8.4.31, 8.4.41, 8.5.6
+* PostCSS 5.2.18, 6.0.23, 7.0.14, 7.0.17, 7.0.21, 7.0.32, 7.0.39, 8.2.13, 8.2.15, 8.3.6, 8.4.5, 8.4.14, 8.4.31, 8.4.41, 8.5.6
 
 ## Installation
 

--- a/docs/els-for-libraries/spring/README.md
+++ b/docs/els-for-libraries/spring/README.md
@@ -39,32 +39,32 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-core | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-jcl | 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-context | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-beans | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-expression | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-jms | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-messaging | 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-aop | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-context-support | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-tx | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-orm | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-aspects | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-core | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-jcl | 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-context | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-beans | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.7.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-expression | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-jms | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-messaging | 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-aop | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-context-support | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-tx | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-orm | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-aspects | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
 | spring-r2dbc | 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-jdbc | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-web | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-webmvc | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-oxm | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-webflux | 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-websocket | 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-framework-bom | 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.21, 6.2.15 |
-| spring-context-indexer | 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-instrument | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-test | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-jdbc | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-web | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.2.13.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.37, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-webmvc | 3.0.5.RELEASE, 3.1.1.RELEASE, 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-oxm | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-webflux | 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-websocket | 4.0.0.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-framework-bom | 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.21, 6.2.15 |
+| spring-context-indexer | 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-instrument | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
+| spring-test | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE, 5.1.5.RELEASE, 5.1.6.RELEASE, 5.1.9.RELEASE, 5.1.20.RELEASE, 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31, 5.3.39, 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
 | spring-core-test | 6.0.16, 6.0.23, 6.1.20, 6.1.21, 6.2.15 |
-| spring-webmvc-portlet | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE |
-| spring-instrument-tomcat | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.30.RELEASE |
+| spring-webmvc-portlet | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE |
+| spring-instrument-tomcat | 3.0.5.RELEASE, 4.1.9.RELEASE, 4.2.9.RELEASE, 4.3.4.RELEASE, 4.3.9.RELEASE, 4.3.25.RELEASE, 4.3.30.RELEASE |
 | spring | 5.2.0.RELEASE, 5.3.7, 5.3.24, 5.3.25, 5.3.27, 5.3.29, 5.3.30, 5.3.31 |
 | framework-docs | 6.0.16, 6.1.21, 6.2.15 |
 </template>
@@ -73,12 +73,12 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-amqp | 2.4.17, 3.1.8 |
-| spring-rabbit | 2.4.17, 3.1.8 |
-| spring-rabbit-junit | 2.4.17, 3.1.8 |
-| spring-rabbit-test | 2.4.17, 3.1.8 |
+| spring-amqp | 2.1.8.RELEASE, 2.3.16, 2.4.17, 3.1.8 |
+| spring-rabbit | 2.1.8.RELEASE, 2.3.16, 2.4.17, 3.1.8 |
+| spring-rabbit-junit | 2.1.8.RELEASE, 2.3.16, 2.4.17, 3.1.8 |
+| spring-rabbit-test | 2.1.8.RELEASE, 2.3.16, 2.4.17, 3.1.8 |
 | spring-rabbit-stream | 2.4.17, 3.1.8 |
-| spring-amqp-dist | 2.4.17, 3.1.8 |
+| spring-amqp-dist | 2.3.16, 2.4.17, 3.1.8 |
 | spring-amqp-bom | 3.1.8 |
 </template>
 
@@ -237,26 +237,26 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 | Module | Version |
 |---|---|
 | spring-security | 5.7.11, 5.7.12, 5.7.14, 5.8.14, 5.8.15, 5.8.16, 6.1.6 |
-| spring-security-bom | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-core | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-config | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-web | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-crypto | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-data | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-ldap | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-messaging | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-oauth2-client | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-oauth2-core | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-oauth2-jose | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-oauth2-resource-server | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-rsocket | 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-saml2-service-provider | 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-test | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-acl | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-aspects | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
-| spring-security-cas | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-bom | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-core | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-config | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-web | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-crypto | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-data | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-ldap | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-messaging | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-oauth2-client | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-oauth2-core | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-oauth2-jose | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-oauth2-resource-server | 5.6.10, 5.7.11, 5.7.12, 5.7.14, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-rsocket | 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-saml2-service-provider | 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-test | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-acl | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-aspects | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
+| spring-security-cas | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
 | spring-security-remoting | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16 |
-| spring-security-taglibs | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3 |
+| spring-security-taglibs | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16, 6.1.6, 6.2.2, 6.3.10, 6.4.3, 6.4.13 |
 | spring-security-openid | 4.2.12.RELEASE, 4.2.20.RELEASE, 5.6.10, 5.8.15, 5.8.16 |
 </template>
 
@@ -271,12 +271,12 @@ ELS for Spring® also patches transitive dependencies at no extra cost, includin
 
 | Module | Version |
 |---|---|
-| spring-ws-core | 3.1.8 |
-| spring-xml | 3.1.8 |
-| spring-ws-security | 3.1.8 |
-| spring-ws-test | 3.1.8 |
-| spring-ws-support | 3.1.8 |
-| spring-ws | 3.1.8 |
+| spring-ws-core | 3.1.8, 4.0.17 |
+| spring-xml | 3.1.8, 4.0.17 |
+| spring-ws-security | 3.1.8, 4.0.17 |
+| spring-ws-test | 3.1.8, 4.0.17 |
+| spring-ws-support | 3.1.8, 4.0.17 |
+| spring-ws | 3.1.8, 4.0.17 |
 </template>
 
 <template #Integration>


### PR DESCRIPTION
JS dedicated pages:
- lodash 4.17.11 (+ install snippet); karma 1.5.0/1.7.0/4.0.0; postcss 8.2.13

javascript-libraries catch-all:
- ws 6.2.1/7.5.9/8.16.0 + dedup-leak 8.18.0/8.20.0; xmlhttprequest-ssl 1.5.1; request 2.65.0; shelljs 0.8.4; protobufjs 5.0.0; brace-expansion 2.1.2; multiparty 2.2.0
- new entries: find-my-way 9.6.0; react-server-dom-esm/-parcel/-turbopack/-webpack

java-libraries catch-all:
- Apache HttpComponents Client 4.5.6/4.5.9/4.5.10

Spring matrices:
- AMQP 2.1.8.RELEASE/2.3.16; Framework 4.3.4/4.3.9/4.3.25.RELEASE and 5.1.6/5.1.9.RELEASE; Security 6.4.13; Web Services 4.0.17

ELSTechnology.vue: synced version strings + new entries (also fixes stale Spring AMQP entry).

Deferred (need Nexus module enumeration): Spring Framework 5.0.x new line, Spring Integration 6.4.10 new major line.