### PR TITLE
Hide local mirror docs from public surfaces

### DIFF
--- a/docs/els-for-os/alpine-linux-3-18-els/README.md
+++ b/docs/els-for-os/alpine-linux-3-18-els/README.md
@@ -61,7 +61,7 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Alpine+Linux+3.18+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Alpine+Linux+3.18+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 
 

--- a/docs/els-for-os/amazon-linux-2-els/README.md
+++ b/docs/els-for-os/amazon-linux-2-els/README.md
@@ -46,6 +46,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Amazon+Linux+2+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Amazon+Linux+2+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/centos-6-els/README.md
+++ b/docs/els-for-os/centos-6-els/README.md
@@ -65,6 +65,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=CentOS+6+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=CentOS+6+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/centos-7-els/README.md
+++ b/docs/els-for-os/centos-7-els/README.md
@@ -66,6 +66,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=CentOS+7+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=CentOS+7+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/centos-8-els/README.md
+++ b/docs/els-for-os/centos-8-els/README.md
@@ -71,6 +71,6 @@
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * [8.4] ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=CentOS+8.4+ELS) — Full list of packages covered by ELS
 * [8.5] ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=CentOS+8.5+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/centos-stream-8-els/README.md
+++ b/docs/els-for-os/centos-stream-8-els/README.md
@@ -65,6 +65,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=CentOS+Stream+8+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=CentOS+Stream+8+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/debian-10-els/README.md
+++ b/docs/els-for-os/debian-10-els/README.md
@@ -70,6 +70,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Debian+10+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Debian+10+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/managing-els-repository/README.md
+++ b/docs/els-for-os/managing-els-repository/README.md
@@ -1,6 +1,6 @@
 # Managing the ELS repository
 
-This page provides instructions for updating packages, setting up a local mirror, and removing the Endless Lifecycle Support (ELS) repository.
+This page provides instructions for updating packages and removing the Endless Lifecycle Support (ELS) repository.
 
 ## Updating packages
 
@@ -61,13 +61,6 @@ For example (packages in the 3rd rollout slot):
 ```
 yum update kernel* --enablerepo=centos7els-rollout-3-bypass
 ```
-
-## Local mirror
-
-TuxCare provides the ability to create local mirrors of ELS repositories using `rsync`. This is useful for environments with restricted internet access or for reducing external bandwidth usage.
-
-To obtain access to the local mirroring facility, provide your external IP address to your Account Manager or contact [sales@tuxcare.com](mailto:sales@tuxcare.com).
-
 
 ## Removing the ELS repository
 

--- a/docs/els-for-os/oracle-linux-6-els/README.md
+++ b/docs/els-for-os/oracle-linux-6-els/README.md
@@ -62,6 +62,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Oracle+Linux+6+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Oracle+Linux+6+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/oracle-linux-7-els/README.md
+++ b/docs/els-for-os/oracle-linux-7-els/README.md
@@ -87,6 +87,6 @@ The installation script **does not automatically add** the TuxCare UEKR6 reposit
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Oracle+Linux+7+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Oracle+Linux+7+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/red-hat-enterprise-linux-7-els/README.md
+++ b/docs/els-for-os/red-hat-enterprise-linux-7-els/README.md
@@ -47,6 +47,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Red+Hat+Enterprise+Linux+7+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Red+Hat+Enterprise+Linux+7+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/red-hat-enterprise-linux-8-els/README.md
+++ b/docs/els-for-os/red-hat-enterprise-linux-8-els/README.md
@@ -46,6 +46,6 @@
 * ![](/images/unlock-alt.webp) [CSAF](https://security.tuxcare.com/csaf/v2/els_os/rhel8els/) — CSAF security advisories
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Red+Hat+Enterprise+Linux+8+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/ubuntu-16-04-els/README.md
+++ b/docs/els-for-os/ubuntu-16-04-els/README.md
@@ -68,6 +68,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Ubuntu+16.04+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Ubuntu+16.04+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/ubuntu-18-04-els/README.md
+++ b/docs/els-for-os/ubuntu-18-04-els/README.md
@@ -68,6 +68,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Ubuntu+18.04+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Ubuntu+18.04+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/els-for-os/ubuntu-20-04-els/README.md
+++ b/docs/els-for-os/ubuntu-20-04-els/README.md
@@ -70,6 +70,6 @@
 * ![](/images/eye.webp) [CVE Tracker](https://tuxcare.com/cve-tracker/?product=Ubuntu+20.04+ELS) — Track vulnerability fixes and updates
 * ![](/images/shield.webp) [Machine-Readable Security Data](/els-for-os/machine-readable-security-data/) — Errata, OVAL, CSAF
 * ![](/images/box.webp) [Supported packages list](https://tuxcare.com/cve-tracker/products/?product=Ubuntu+20.04+ELS) — Full list of packages covered by ELS
-* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates, local mirror, and other repository operations
+* ![](/images/wrench.webp) [Managing the ELS repository](/els-for-os/managing-els-repository/) — Updates and other repository operations
 
 </WhatsNext>

--- a/docs/local-mirror-els/README.md
+++ b/docs/local-mirror-els/README.md
@@ -1,3 +1,9 @@
+---
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
 <!-- markdownlint-disable MD040 MD033 -->
 
 # Installation instructions of a local mirror with ELS updates

--- a/docs/local-mirror-for-els-nodejs/README.md
+++ b/docs/local-mirror-for-els-nodejs/README.md
@@ -1,3 +1,9 @@
+---
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
 # Installation instructions of a local mirror for ELS Node.js
 
 We provide the ability to create local mirrors of Node.js for ELS updates.

--- a/docs/local-mirror-for-els-php/README.md
+++ b/docs/local-mirror-for-els-php/README.md
@@ -1,3 +1,9 @@
+---
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
 # Installation instructions of a local mirror for ELS PHP
 
 We provide the ability to create local mirrors of PHP for ELS updates.

--- a/docs/local-mirror-for-els-python/README.md
+++ b/docs/local-mirror-for-els-python/README.md
@@ -1,3 +1,9 @@
+---
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
 # Installation instructions of a local mirror for ELS Python
 
 We provide the ability to create local mirrors of Python for ELS updates.

--- a/docs/local-mirror-for-els-ruby/README.md
+++ b/docs/local-mirror-for-els-ruby/README.md
@@ -1,3 +1,9 @@
+---
+head:
+  - - meta
+    - name: robots
+      content: noindex, nofollow
+---
 # Installation instructions of a local mirror for ELS Ruby
 
 We provide the ability to create local mirrors of Ruby for ELS updates.

--- a/scripts/generate-llms-full.mjs
+++ b/scripts/generate-llms-full.mjs
@@ -27,7 +27,19 @@ const REPO = resolve(__dirname, "..");
 const DOCS = join(REPO, "docs");
 const SITE = "https://docs.tuxcare.com";
 const OUT = join(DOCS, ".vuepress", "public", "llms-full.txt");
-const EXCLUDE_DIRS = new Set([".vuepress", "_pages-backup", "node_modules"]);
+const EXCLUDE_DIRS = new Set([
+  ".vuepress",
+  "_pages-backup",
+  "node_modules",
+  // Local mirror pages are intentionally undocumented publicly: they exist so
+  // qualified customers can be sent a direct link, but must not be surfaced in
+  // navigation, search, or the LLM corpus. Keep them out of llms-full.txt.
+  "local-mirror-els",
+  "local-mirror-for-els-nodejs",
+  "local-mirror-for-els-php",
+  "local-mirror-for-els-python",
+  "local-mirror-for-els-ruby",
+]);
 
 // CamelCase component name: starts uppercase, contains at least one lowercase.
 const COMP = "[A-Z][A-Za-z0-9]*[a-z][A-Za-z0-9]*";


### PR DESCRIPTION


- Drop the "## Local mirror" section and its mention in the els-for-os/managing-els-repository page.
- Reword the "Related resources" link on all 14 ELS-for-OS landing pages so it no longer advertises "local mirror".
- Exclude the five local-mirror pages from llms-full.txt generation so the capability is absent from the LLM corpus (llms.txt already omits them).
- Add `robots: noindex, nofollow` meta to the five local-mirror pages so search engines do not index them, while the pages stay live.
