### PR TITLE
ELSDOC-369: add net-new Java library versions (2026-08-04 to 08-05)

### DIFF
--- a/docs/.vuepress/components/ELSTechnology.vue
+++ b/docs/.vuepress/components/ELSTechnology.vue
@@ -116,7 +116,7 @@ const techData = [
       },
       {
         name: "Apache Commons Compress",
-        versions: "1.8.1 | 1.18 | 1.19 | 1.20 | 1.21 | 1.26.2",
+        versions: "1.8.1 | 1.12 | 1.18 | 1.19 | 1.20 | 1.21 | 1.26.2",
         link: "./java-libraries/",
       },
       {
@@ -131,7 +131,7 @@ const techData = [
       },
       {
         name: "Apache Commons FileUpload",
-        versions: "1.2.1 | 1.2.2 | 1.5",
+        versions: "1.2.1 | 1.2.2 | 1.3.1 | 1.5",
         link: "./java-libraries/",
       },
       {
@@ -477,7 +477,7 @@ const techData = [
       },
       {
         name: "jsoup",
-        versions: "1.7.2",
+        versions: "1.7.2 | 1.7.3",
         link: "./java-libraries/",
       },
       {
@@ -492,7 +492,7 @@ const techData = [
       },
       {
         name: "Logback",
-        versions: "1.1.7 | 1.2.13 | 1.4.11 | 1.4.14 | 1.5.18",
+        versions: "1.1.7 | 1.2.12 | 1.2.13 | 1.4.11 | 1.4.14 | 1.5.18",
         link: "./java-libraries/",
       },
       {
@@ -557,7 +557,7 @@ const techData = [
       },
       {
         name: "Plexus Utils",
-        versions: "1.4.5 | 1.5.5 | 1.5.8 | 3.1.0 | 3.6.0",
+        versions: "1.4.5 | 1.5.5 | 1.5.8 | 3.1.0 | 3.5.1 | 3.6.0",
         link: "./java-libraries/",
       },
       {

--- a/docs/els-for-libraries/java-libraries/README.md
+++ b/docs/els-for-libraries/java-libraries/README.md
@@ -10,10 +10,10 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Apache Axis** 1.4
 * **Apache Commons BeanUtils** 1.6, 1.8.0, 1.8.3, 1.9.4, 1.10.1
 * **Apache Commons Collections** 3.2, 3.2.1
-* **Apache Commons Compress** 1.8.1, 1.18, 1.19, 1.20, 1.21, 1.26.2
+* **Apache Commons Compress** 1.8.1, 1.12, 1.18, 1.19, 1.20, 1.21, 1.26.2
 * **Apache Commons Configuration** 2.12.0
 * **Apache Commons Digester** 2.0, 2.1
-* **Apache Commons FileUpload** 1.2.1, 1.2.2, 1.5
+* **Apache Commons FileUpload** 1.2.1, 1.2.2, 1.3.1, 1.5
 * **Apache Commons HttpClient** 3.1
 * **Apache Commons IO** 2.4, 2.5, 2.6, 2.7, 2.8.0, 2.11.0
 * **Apache Commons VFS** 2.0
@@ -64,10 +64,10 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **JSON Assert** 1.2.3
 * **JSON Smart v2** 1.3.2, 2.4.8
 * **json-io** 2.9.4
-* **jsoup** 1.7.2
+* **jsoup** 1.7.2, 1.7.3
 * **JUnit** 4.13
 * **Lettuce** 6.1.10.RELEASE
-* **Logback** 1.1.7, 1.2.13, 1.4.11, 1.4.14, 1.5.18
+* **Logback** 1.1.7, 1.2.12, 1.2.13, 1.4.11, 1.4.14, 1.5.18
 * **LZ4** 1.8.1
 * **mchange-commons-java** 0.2.15, 0.2.19, 0.2.20
 * **Mozilla Rhino** 1.7.10, 1.7.15
@@ -80,7 +80,7 @@ Endless Lifecycle Support (ELS) for Libraries from TuxCare provides security fix
 * **Nimbus OAuth2 OIDC SDK** 9.43.3, 9.43.6
 * **OkHttp3** 3.14.9, 4.10.0
 * **Okio** 2.8.0, 2.10.0
-* **Plexus Utils** 1.4.5, 1.5.5, 1.5.8, 3.1.0, 3.6.0
+* **Plexus Utils** 1.4.5, 1.5.5, 1.5.8, 3.1.0, 3.5.1, 3.6.0
 * **Quartz Scheduler** 1.8.5
 * **Querydsl** 5.1.0
 * **Reactor BOM** 2020.0.0, 2020.0.7, 2020.0.23, 2020.0.32, 2020.0.38, 2022.0.15


### PR DESCRIPTION
Backfill/interstitial upstream lines from the els_java Nexus scan:
- Apache Commons Compress 1.12
- Apache Commons FileUpload 1.3.1
- jsoup 1.7.3
- Logback 1.2.12
- Plexus Utils 3.5.1

Added to the java-libraries catch-all supported-versions list and the ELSTechnology.vue version strings.
